### PR TITLE
Enable https redirect with middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^4.0.0",
         "next": "12.2.0",
+        "next-ssl-redirect-middleware": "^0.1.4",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -2293,6 +2294,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-ssl-redirect-middleware": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/next-ssl-redirect-middleware/-/next-ssl-redirect-middleware-0.1.4.tgz",
+      "integrity": "sha512-SWJBDyyI+5imAW11TWDXSsuu8VB/c2eHF3Va2T20/0mSASIOZrTnmoVxLcYTzv+elki8hbetAeb1jDtQiQ0Y0Q=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4811,6 +4817,11 @@
         "styled-jsx": "5.0.2",
         "use-sync-external-store": "1.1.0"
       }
+    },
+    "next-ssl-redirect-middleware": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/next-ssl-redirect-middleware/-/next-ssl-redirect-middleware-0.1.4.tgz",
+      "integrity": "sha512-SWJBDyyI+5imAW11TWDXSsuu8VB/c2eHF3Va2T20/0mSASIOZrTnmoVxLcYTzv+elki8hbetAeb1jDtQiQ0Y0Q=="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@prisma/client": "^4.0.0",
     "next": "12.2.0",
+    "next-ssl-redirect-middleware": "^0.1.4",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -1,0 +1,3 @@
+import sslRedirect from "next-ssl-redirect-middleware";
+
+export default sslRedirect({});


### PR DESCRIPTION
Otetaan käyttöön middleware, joka ohjaa tuotantoympäristössä http-pyynnöt https:ään, koska Heroku ei sitä itse tee. Olin laiska ja otin käyttöön valmiin npm-paketin, joka tosin on onneksi sangen yksinkertainen ja tarvittaessa korvattavissa itse.