### PR TITLE
rename tournament date columns

### DIFF
--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -9,10 +9,10 @@ export const getStaticProps: GetStaticProps = async () => {
     select: {
       id: true,
       name: true,
-      start: true,
-      end: true,
-      registrationStart: true,
-      registrationEnd: true,
+      startTime: true,
+      endTime: true,
+      registrationStartTime: true,
+      registrationEndTime: true,
       players: true,
       umpires: true
     }
@@ -21,10 +21,10 @@ export const getStaticProps: GetStaticProps = async () => {
   tournaments.map((tournament) =>
     newTournaments.push({
       ...tournament,
-      start: tournament.start.toString(),
-      end: tournament.end.toString(),
-      registrationStart: tournament.registrationStart.toString(),
-      registrationEnd: tournament.registrationEnd.toString()
+      startTime: tournament.startTime.toString(),
+      endTime: tournament.endTime.toString(),
+      registrationStartTime: tournament.registrationStartTime.toString(),
+      registrationEndTime: tournament.registrationEndTime.toString()
     })
   );
   newTournaments = JSON.parse(JSON.stringify(newTournaments));
@@ -58,11 +58,11 @@ export default function Admin({ newTournaments }) {
               <a>{tournament.name}</a>
             </Link>
 
-            <p>Alkaa: {modifyDate(tournament.start)}</p>
-            <p>Päättyy: {modifyDate(tournament.end)}</p>
+            <p>Alkaa: {modifyDate(tournament.startTime)}</p>
+            <p>Päättyy: {modifyDate(tournament.endTime)}</p>
             <p>
-              Ilmoittautuminen: {modifyDate(tournament.registrationStart)} -
-              {modifyDate(tournament.registrationEnd)}
+              Ilmoittautuminen: {modifyDate(tournament.registrationStartTime)} -
+              {modifyDate(tournament.registrationEndTime)}
             </p>
           </div>
         ))}

--- a/pages/admin/create.tsx
+++ b/pages/admin/create.tsx
@@ -32,10 +32,10 @@ export default function CreateTournament() {
 
     const data = {
       name: event.target.tournament_label.value,
-      start: new Date(event.target.start.value),
-      end: new Date(event.target.end.value),
-      registrationStart: startDate,
-      registrationEnd: endDate
+      startTime: new Date(event.target.start.value),
+      endTime: new Date(event.target.end.value),
+      registrationStartTime: startDate,
+      registrationEndTime: endDate
     };
 
     fetch("/api/tournament/create", {

--- a/pages/api/tournament/create.ts
+++ b/pages/api/tournament/create.ts
@@ -3,10 +3,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 type Tournament = {
   name: string;
-  start: Date;
-  end: Date;
-  registrationStart: Date;
-  registrationEnd: Date;
+  startTime: Date;
+  endTime: Date;
+  registrationStartTime: Date;
+  registrationEndTime: Date;
 };
 
 export default async function create(
@@ -17,13 +17,7 @@ export default async function create(
     const tournament: Tournament = JSON.parse(req.body);
 
     const result = await prisma.tournament.create({
-      data: {
-        name: tournament.name,
-        start: tournament.start,
-        end: tournament.end,
-        registrationStart: tournament.registrationStart,
-        registrationEnd: tournament.registrationEnd
-      }
+      data: tournament
     });
     res.status(201).end();
   }

--- a/pages/registration/[id].tsx
+++ b/pages/registration/[id].tsx
@@ -17,10 +17,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     select: {
       id: true,
       name: true,
-      start: true,
-      end: true,
-      registrationStart: true,
-      registrationEnd: true
+      startTime: true,
+      endTime: true,
+      registrationStartTime: true,
+      registrationEndTime: true
     }
   });
   tournament = JSON.parse(JSON.stringify(tournament)); // to avoid Next.js serialization error

--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -29,10 +29,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   let tournament = await prisma.tournament.findFirst({
     select: {
       name: true,
-      start: true,
-      end: true,
-      registrationStart: true,
-      registrationEnd: true
+      startTime: true,
+      endTime: true,
+      registrationStartTime: true,
+      registrationEndTime: true
     }
   });
   tournament = JSON.parse(JSON.stringify(tournament)); // avoid Next.js serialization error
@@ -100,8 +100,8 @@ export default function UserInfo({
     }
   }, []);
 
-  const start = new Date(tournament.start);
-  const end = new Date(tournament.end);
+  const start = new Date(tournament.startTime);
+  const end = new Date(tournament.endTime);
   let dates: Array<any> = [];
   dates.push(`${start.getDate()}.${start.getMonth() + 1}.`);
   let loopDay = start;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,18 +67,18 @@ model Umpire {
 }
 
 model Tournament {
-  id                String           @id @default(uuid())
-  createdAt         DateTime         @default(now()) @db.Timestamptz(3)
-  modifiedAt        DateTime         @default(now()) @db.Timestamptz(3)
-  name              String
-  start             DateTime         @db.Timestamptz(3)
-  end               DateTime         @db.Timestamptz(3)
-  registrationStart DateTime         @db.Timestamptz(3)
-  registrationEnd   DateTime         @db.Timestamptz(3)
-  players           Player[]
-  umpires           Umpire[]
-  rings             AssignmentRing[]
-  users             User[]
+  id                    String           @id @default(uuid())
+  createdAt             DateTime         @default(now()) @db.Timestamptz(3)
+  modifiedAt            DateTime         @default(now()) @db.Timestamptz(3)
+  name                  String
+  startTime             DateTime         @db.Timestamptz(3)
+  endTime               DateTime         @db.Timestamptz(3)
+  registrationStartTime DateTime         @db.Timestamptz(3)
+  registrationEndTime   DateTime         @db.Timestamptz(3)
+  players               Player[]
+  umpires               Umpire[]
+  rings                 AssignmentRing[]
+  users                 User[]
 }
 
 model Assignment {


### PR DESCRIPTION
`end` on tosiaan varattu sana SQL:ssä, joten uudelleennimetään se endTimeksi ja noudatetaan samaa kaavaa loppujenkin turnauksen päivämäärien kanssa. Harmittavasti tosin tämä jyrää tietokannan vanhan datan täysin.