### PR TITLE
Move everything except registration behind login; prevent login from non-umpire players for now

### DIFF
--- a/components/AuthenticationRequired.tsx
+++ b/components/AuthenticationRequired.tsx
@@ -9,7 +9,7 @@ export const AuthenticationRequired = (props): JSX.Element => {
       <>
         Et ole kirjautunut sisään.
         <br />
-        {/* <button onClick={() => signIn("email", { callbackUrl: "/" })}>
+        {/* <button onClick={() => signIn("email", { callbackUrl: "/personal" })}>
           Kirjaudu sisään
         </button> */}
       </>

--- a/components/AuthenticationRequired.tsx
+++ b/components/AuthenticationRequired.tsx
@@ -9,7 +9,9 @@ export const AuthenticationRequired = (props): JSX.Element => {
       <>
         Et ole kirjautunut sisään.
         <br />
-        {/* <button onClick={() => signIn()}>Kirjaudu sisään</button> */}
+        {/* <button onClick={() => signIn("email", { callbackUrl: "/" })}>
+          Kirjaudu sisään
+        </button> */}
       </>
     );
   }

--- a/components/AuthenticationRequired.tsx
+++ b/components/AuthenticationRequired.tsx
@@ -1,5 +1,6 @@
 import { signIn, useSession } from "next-auth/react";
-export const RestrictedAccess = (props): JSX.Element => {
+
+export const AuthenticationRequired = (props): JSX.Element => {
   const { data: session } = useSession();
   if (session) {
     return <>{props.children}</>;

--- a/components/AuthenticationRequired.tsx
+++ b/components/AuthenticationRequired.tsx
@@ -9,7 +9,7 @@ export const AuthenticationRequired = (props): JSX.Element => {
       <>
         Et ole kirjautunut sisään.
         <br />
-        <button onClick={() => signIn()}>Kirjaudu sisään</button>
+        {/* <button onClick={() => signIn()}>Kirjaudu sisään</button> */}
       </>
     );
   }

--- a/components/RestrictedAccess.tsx
+++ b/components/RestrictedAccess.tsx
@@ -1,0 +1,15 @@
+import { signIn, useSession } from "next-auth/react";
+export const RestrictedAccess = (props): JSX.Element => {
+  const { data: session } = useSession();
+  if (session) {
+    return <>{props.children}</>;
+  } else {
+    return (
+      <>
+        Et ole kirjautunut sisään.
+        <br />
+        <button onClick={() => signIn()}>Kirjaudu sisään</button>
+      </>
+    );
+  }
+};

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -2,6 +2,7 @@ import { GetStaticProps } from "next";
 import prisma from "../lib/prisma";
 import { useRouter } from "next/router";
 import Link from "next/link";
+import { AuthenticationRequired } from "../components/AuthenticationRequired";
 
 export const getStaticProps: GetStaticProps = async () => {
   let tournaments = await prisma.tournament.findMany({
@@ -47,24 +48,26 @@ export default function Admin({ newTournaments }) {
     return formattedDate;
   };
   return (
-    <div>
+    <AuthenticationRequired>
       <div>
-        <button onClick={switchPage}>Lisää turnaus</button>
-      </div>
-      {newTournaments.map((tournament) => (
-        <div key={tournament.id}>
-          <Link href={`/admin/${tournament.id}/`}>
-            <a>{tournament.name}</a>
-          </Link>
-
-          <p>Alkaa: {modifyDate(tournament.start)}</p>
-          <p>Päättyy: {modifyDate(tournament.end)}</p>
-          <p>
-            Ilmoittautuminen: {modifyDate(tournament.registrationStart)} -
-            {modifyDate(tournament.registrationEnd)}
-          </p>
+        <div>
+          <button onClick={switchPage}>Lisää turnaus</button>
         </div>
-      ))}
-    </div>
+        {newTournaments.map((tournament) => (
+          <div key={tournament.id}>
+            <Link href={`/admin/${tournament.id}/`}>
+              <a>{tournament.name}</a>
+            </Link>
+
+            <p>Alkaa: {modifyDate(tournament.start)}</p>
+            <p>Päättyy: {modifyDate(tournament.end)}</p>
+            <p>
+              Ilmoittautuminen: {modifyDate(tournament.registrationStart)} -
+              {modifyDate(tournament.registrationEnd)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </AuthenticationRequired>
   );
 }

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -1,4 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from "next";
+import { AuthenticationRequired } from "../../components/AuthenticationRequired";
 import { TournamentRings } from "../../components/TournamentRings";
 import prisma from "../../lib/prisma";
 
@@ -44,14 +45,16 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 export default function Tournament({ tournament, players, rings }) {
   return (
-    <div>
-      <h2>{tournament.name}</h2>
-      <TournamentRings
-        tournament={tournament}
-        players={players}
-        rings={rings}
-      />
-    </div>
+    <AuthenticationRequired>
+      <div>
+        <h2>{tournament.name}</h2>
+        <TournamentRings
+          tournament={tournament}
+          players={players}
+          rings={rings}
+        />
+      </div>
+    </AuthenticationRequired>
   );
 }
 

--- a/pages/admin/create.tsx
+++ b/pages/admin/create.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { RestrictedAccess } from "../../components/RestrictedAccess";
+import { AuthenticationRequired } from "../../components/AuthenticationRequired";
 
 export default function CreateTournament() {
   const router = useRouter();
@@ -46,7 +46,7 @@ export default function CreateTournament() {
     });
   };
   return (
-    <RestrictedAccess>
+    <AuthenticationRequired>
       <div>
         <h2>Turnauksen luominen</h2>
         <form onSubmit={handleSubmit}>
@@ -96,6 +96,6 @@ export default function CreateTournament() {
           <button type="submit">Luo turnaus</button>
         </form>
       </div>
-    </RestrictedAccess>
+    </AuthenticationRequired>
   );
 }

--- a/pages/admin/create.tsx
+++ b/pages/admin/create.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import { RestrictedAccess } from "../../components/RestrictedAccess";
 
 export default function CreateTournament() {
   const router = useRouter();
@@ -45,54 +46,56 @@ export default function CreateTournament() {
     });
   };
   return (
-    <div>
-      <h2>Turnauksen luominen</h2>
-      <form onSubmit={handleSubmit}>
-        <label htmlFor="tournament_label">
-          Turnauksen nimi:
-          <input
-            type="text"
-            id="tournament_label"
-            name="tournament_label"
-          ></input>
-        </label>
-        <label htmlFor="start">
-          Aloituspäivämäärä:
-          <input type="date" id="start" name="start"></input>
-        </label>
-        <label htmlFor="end">
-          Lopetuspäivämäärä:
-          <input type="date" id="end" name="end"></input>
-        </label>
-        <h3>Ilmoittautuminen</h3>
-        <label htmlFor="registration_start">
-          alkaa
-          <input
-            type="date"
-            id="registration_start"
-            name="registration_start"
-          ></input>
-          <input
-            type="time"
-            id="registration_time_start"
-            name="registration_time_start"
-          ></input>
-        </label>
-        <label htmlFor="registration_end">
-          päättyy
-          <input
-            type="date"
-            id="registration_end"
-            name="registration_end"
-          ></input>
-          <input
-            type="time"
-            id="registration_time_end"
-            name="registration_time_end"
-          ></input>
-        </label>
-        <button type="submit">Luo turnaus</button>
-      </form>
-    </div>
+    <RestrictedAccess>
+      <div>
+        <h2>Turnauksen luominen</h2>
+        <form onSubmit={handleSubmit}>
+          <label htmlFor="tournament_label">
+            Turnauksen nimi:
+            <input
+              type="text"
+              id="tournament_label"
+              name="tournament_label"
+            ></input>
+          </label>
+          <label htmlFor="start">
+            Aloituspäivämäärä:
+            <input type="date" id="start" name="start"></input>
+          </label>
+          <label htmlFor="end">
+            Lopetuspäivämäärä:
+            <input type="date" id="end" name="end"></input>
+          </label>
+          <h3>Ilmoittautuminen</h3>
+          <label htmlFor="registration_start">
+            alkaa
+            <input
+              type="date"
+              id="registration_start"
+              name="registration_start"
+            ></input>
+            <input
+              type="time"
+              id="registration_time_start"
+              name="registration_time_start"
+            ></input>
+          </label>
+          <label htmlFor="registration_end">
+            päättyy
+            <input
+              type="date"
+              id="registration_end"
+              name="registration_end"
+            ></input>
+            <input
+              type="time"
+              id="registration_time_end"
+              name="registration_time_end"
+            ></input>
+          </label>
+          <button type="submit">Luo turnaus</button>
+        </form>
+      </div>
+    </RestrictedAccess>
   );
 }

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -18,7 +18,29 @@ export const authConfig = {
       },
       from: "Surma authorization <no-reply.surma@salamurhaajat.net>"
     })
-  ]
+  ],
+  callbacks: {
+    async signIn({ user, account, profile, email, credentials }) {
+      const currentUser = await prisma.user.findUnique({
+        where: {
+          id: user.id
+        },
+        select: {
+          umpire: true
+        }
+      });
+      console.log("user umpire", currentUser.umpire);
+      const isAllowedToSignIn = currentUser.umpire != null; // EI-TUOMARIPELAAJAT EIVÄT SAA KIRJAUTUA VIELÄ
+      if (isAllowedToSignIn) {
+        return true;
+      } else {
+        // Return false to display a default error message
+        return false;
+        // Or you can return a URL to redirect to:
+        // return '/unauthorized'
+      }
+    }
+  }
 };
 
 export default NextAuth(authConfig);

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,7 @@ import EmailProvider from "next-auth/providers/email";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import prisma from "../../../lib/prisma";
 
-export default NextAuth({
+export const authConfig = {
   adapter: PrismaAdapter(prisma),
   providers: [
     // Passwordless / email sign in
@@ -19,4 +19,6 @@ export default NextAuth({
       from: "Surma authorization <no-reply.surma@salamurhaajat.net>"
     })
   ]
-});
+};
+
+export default NextAuth(authConfig);

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,4 @@
-import NextAuth from "next-auth";
+import NextAuth, { DefaultSession } from "next-auth";
 import EmailProvider from "next-auth/providers/email";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import prisma from "../../../lib/prisma";
@@ -35,8 +35,7 @@ export const authConfig = {
           umpire: true
         }
       });
-      console.log("user umpire", currentUser.umpire);
-      const isAllowedToSignIn = currentUser.umpire != null; // EI-TUOMARIPELAAJAT EIVÄT SAA KIRJAUTUA VIELÄ
+      const isAllowedToSignIn = true; // currentUser.umpire != null; // EI-TUOMARIPELAAJAT EIVÄT SAA KIRJAUTUA VIELÄ
       if (isAllowedToSignIn) {
         return true;
       } else {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -20,6 +20,12 @@ export const authConfig = {
     })
   ],
   callbacks: {
+    async session({ session, token, user }) {
+      return {
+        ...session,
+        user: { id: user.id, ...session.user }
+      };
+    },
     async signIn({ user, account, profile, email, credentials }) {
       const currentUser = await prisma.user.findUnique({
         where: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ export default function Home() {
     <>
       Et ole kirjautunut sisään.
       <br />
-      {/* <button onClick={() => signIn("email", { callbackUrl: "/" })}>
+      {/* <button onClick={() => signIn("email", { callbackUrl: "/personal" })}>
         Kirjaudu sisään
       </button> */}
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,9 @@ export default function Home() {
     <>
       Et ole kirjautunut sisään.
       <br />
-      {/* <button onClick={() => signIn()}>Kirjaudu sisään</button> */}
+      {/* <button onClick={() => signIn("email", { callbackUrl: "/" })}>
+        Kirjaudu sisään
+      </button> */}
     </>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ export default function Home() {
     <>
       Et ole kirjautunut sisään.
       <br />
-      <button onClick={() => signIn()}>Kirjaudu sisään</button>
+      {/* <button onClick={() => signIn()}>Kirjaudu sisään</button> */}
     </>
   );
 }

--- a/pages/personal.tsx
+++ b/pages/personal.tsx
@@ -1,0 +1,21 @@
+import { unstable_getServerSession } from "next-auth";
+import { authConfig } from "./api/auth/[...nextauth]";
+import { AuthenticationRequired } from "../components/AuthenticationRequired";
+
+export async function getServerSideProps(context) {
+  const session = await unstable_getServerSession(
+    context.req,
+    context.res,
+    authConfig
+  );
+  return {
+    redirect: {
+      destination: "/tournaments/users/".concat(session.user.id),
+      permanent: false
+    }
+  };
+}
+
+export default function Personal(): JSX.Element {
+  return <AuthenticationRequired></AuthenticationRequired>;
+}

--- a/pages/tournaments/targets/[id].tsx
+++ b/pages/tournaments/targets/[id].tsx
@@ -2,6 +2,7 @@ import { Prisma, Player } from "@prisma/client";
 import { GetStaticProps } from "next";
 import { PlayerDetails } from "../../../components/PlayerDetails";
 import prisma from "../../../lib/prisma";
+import { AuthenticationRequired } from "../../../components/AuthenticationRequired";
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const playerAsTarget: Prisma.PlayerSelect = {
@@ -33,12 +34,14 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 export default function Target(player): JSX.Element {
   return (
-    <div>
-      <h1>
-        {player.user.firstName} {player.user.lastName}
-      </h1>
-      <PlayerDetails player={player} />
-    </div>
+    <AuthenticationRequired>
+      <div>
+        <h1>
+          {player.user.firstName} {player.user.lastName}
+        </h1>
+        <PlayerDetails player={player} />
+      </div>
+    </AuthenticationRequired>
   );
 }
 

--- a/pages/tournaments/users.tsx
+++ b/pages/tournaments/users.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { GetStaticProps } from "next";
 import prisma from "../../lib/prisma";
+import { AuthenticationRequired } from "../../components/AuthenticationRequired";
 
 export const getStaticProps: GetStaticProps = async () => {
   const objects = await prisma.user.findMany({
@@ -25,7 +26,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
 export default function UserList({ objects }) {
   return (
-    <>
+    <AuthenticationRequired>
       <h1>List of users</h1>
       <ul>
         {objects.map(
@@ -49,6 +50,6 @@ export default function UserList({ objects }) {
           }
         )}
       </ul>
-    </>
+    </AuthenticationRequired>
   );
 }

--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { UpdateForm } from "../../../components/UpdateForm";
 import { useRouter } from "next/router";
 import Image from "next/image";
+import { AuthenticationRequired } from "../../../components/AuthenticationRequired";
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   require("dotenv").config();
@@ -156,52 +157,54 @@ export default function UserInfo({
   };
 
   return (
-    <div>
-      {notification ? (
-        <p className="notification">Ilmoittautuminen onnistui!</p>
-      ) : null}
-      {isUpdated ? (
-        <div>
-          <h1>
-            {user.firstName} {user.lastName}
-          </h1>
-          {imageUrl !== "" ? (
-            <div>
-              {showPicture ? (
-                <div>
-                  <Image src={imageUrl} width={200} height={100}></Image>
-                </div>
-              ) : null}
-              <button onClick={togglePicture}>
-                {showPicture ? "piilota" : "näytä kuva"}
-              </button>
-            </div>
-          ) : (
-            <p>Ei kuvaa</p>
-          )}
-
-          <PlayerContactInfo user={user} />
-          <PlayerDetails player={user.player} />
-        </div>
-      ) : (
-        <div>
-          <h1>
-            {user.firstName} {user.lastName}
-          </h1>
-          <PlayerContactInfo user={user} />
-          <UpdateForm
-            data={user.player}
-            handleSubmit={handleSubmit}
-            calendar={user.player.calendar}
-          />
-        </div>
-      )}
+    <AuthenticationRequired>
       <div>
-        <button onClick={handleUpdateStatusClick}>
-          {isUpdated ? "muokkaa tietoja" : "peruuta"}
-        </button>
+        {notification ? (
+          <p className="notification">Ilmoittautuminen onnistui!</p>
+        ) : null}
+        {isUpdated ? (
+          <div>
+            <h1>
+              {user.firstName} {user.lastName}
+            </h1>
+            {imageUrl !== "" ? (
+              <div>
+                {showPicture ? (
+                  <div>
+                    <Image src={imageUrl} width={200} height={100}></Image>
+                  </div>
+                ) : null}
+                <button onClick={togglePicture}>
+                  {showPicture ? "piilota" : "näytä kuva"}
+                </button>
+              </div>
+            ) : (
+              <p>Ei kuvaa</p>
+            )}
+
+            <PlayerContactInfo user={user} />
+            <PlayerDetails player={user.player} />
+          </div>
+        ) : (
+          <div>
+            <h1>
+              {user.firstName} {user.lastName}
+            </h1>
+            <PlayerContactInfo user={user} />
+            <UpdateForm
+              data={user.player}
+              handleSubmit={handleSubmit}
+              calendar={user.player.calendar}
+            />
+          </div>
+        )}
+        <div>
+          <button onClick={handleUpdateStatusClick}>
+            {isUpdated ? "muokkaa tietoja" : "peruuta"}
+          </button>
+        </div>
       </div>
-    </div>
+    </AuthenticationRequired>
   );
 }
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import NextAuth from "next-auth";
+
+declare module "next-auth" {
+  /**
+   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: {
+      id: string;
+      email: string;
+    };
+  }
+}


### PR DESCRIPTION
Rajataan kirjautumattomien käyttäjien pääsy ainoastaan ilmoittautumissivulle.

Yritin tovin ympätä tätä login-tarkistusta tuonne middlewareen, mikä olisi oikeasti se fiksumpi paikka tällaiselle, mutta en löytänyt tapaa saada sitä toimimaan tuon https-redirect-middlewaren kanssa, ja next-authin oma valmisratkaisu toimii tällä hetkellä vain JWT-sessioiden kanssa, kun taas Surma käyttää tietokantaan varastoitua sessiota (opinpahan näidenkin kahden eron samalla).

Päädyin nyt sitten tekemään tuollaisen `AuthenticationRequired`-wrapper-componentin, joka näyttää sisältönsä vain jos käyttäjä on kirjautunut. Kurjin puoli siinä on, että se on lisättävä jokaiselle sivulle, jonka haluaa piilotettavan kirjautumattomalta käyttäjältä. Ns. opt-out-henkinen ratkaisu olisi ollut turvallisempi ja parempi, mutta tällä mennään kun ei parempaakaan ole.

Pitäisi vielä lisätä sessiotarkistukset myös tuonne api-sivuihin ja *Props-funkkareihin, mutta tällä pääsee ainakin alkuun.