### PR TITLE
Fix things that break with non-player users

### DIFF
--- a/pages/tournaments/players.tsx
+++ b/pages/tournaments/players.tsx
@@ -21,7 +21,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
   };
 };
 
-export default function UserList({ objects }) {
+export default function PlayerList({ objects }) {
   return (
     <AuthenticationRequired>
       <h1>List of players</h1>

--- a/pages/tournaments/players.tsx
+++ b/pages/tournaments/players.tsx
@@ -1,18 +1,15 @@
 import Link from "next/link";
-import { GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 import prisma from "../../lib/prisma";
 import { AuthenticationRequired } from "../../components/AuthenticationRequired";
 
-export const getStaticProps: GetStaticProps = async () => {
-  const objects = await prisma.user.findMany({
+export const getServerSideProps: GetServerSideProps = async () => {
+  const objects = await prisma.player.findMany({
     select: {
       id: true,
-      firstName: true,
-      lastName: true,
-      player: {
-        select: {
-          alias: true
-        }
+      alias: true,
+      user: {
+        select: { firstName: true, lastName: true }
       }
     }
   });
@@ -27,22 +24,22 @@ export const getStaticProps: GetStaticProps = async () => {
 export default function UserList({ objects }) {
   return (
     <AuthenticationRequired>
-      <h1>List of users</h1>
+      <h1>List of players</h1>
       <ul>
         {objects.map(
           (o: {
             id: string;
-            firstName: string;
-            lastName: string;
-            player: {
-              alias: string;
+            alias: string;
+            user: {
+              firstName: string;
+              lastName: string;
             };
           }) => {
             return (
               <li key={o.id}>
                 <Link href={`/tournaments/users/${o.id}`}>
                   <a>
-                    {o.firstName} {o.lastName} ({o.player.alias})
+                    {o.user.firstName} {o.user.lastName} ({o.alias})
                   </a>
                 </Link>
               </li>

--- a/pages/tournaments/targets/[id].tsx
+++ b/pages/tournaments/targets/[id].tsx
@@ -46,7 +46,7 @@ export default function Target(player): JSX.Element {
 }
 
 export async function getStaticPaths() {
-  const targetIds = await prisma.user.findMany({ select: { id: true } });
+  const targetIds = await prisma.player.findMany({ select: { id: true } });
   return {
     paths: targetIds.map((target) => ({
       params: target


### PR DESCRIPTION
Loin testiturnauksen ja sille kaksi tuomaria ja yritin viedä viimeisimmät muutokset tuotantoon. Buildi hajosi, koska meillä oli pari sivua, jotka olettivat kaikkien käyttäjien olevan pelaajia. Korjasin nämä nyt muuttamalla UserListin pelaajalistaukseksi ja käyttämällä kohdesivujen getStaticPathsissa player-id:itä user-id:iden sijaan.