### PR TITLE
access control for server side props

### DIFF
--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -18,6 +18,8 @@ const isCurrentUserAuthorized = async (tournamentId, context) => {
       tournamentId: tournamentId
     }
   });
+  console.log("access check for tournament", tournamentId);
+  console.log("checking current user umpire status:", umpire);
   return umpire != null;
 };
 
@@ -25,9 +27,11 @@ export const getServerSideProps: GetServerSideProps = async ({
   params,
   ...context
 }) => {
-  if (await !isCurrentUserAuthorized(params.id, context))
+  if (!(await isCurrentUserAuthorized(params.id, context))) {
+    console.log("is not authorized!");
     return { redirect: { destination: "/personal", permanent: false } };
-
+  }
+  console.log("is authorized!");
   let tournament = await prisma.tournament.findUnique({
     where: {
       id: params.id as string

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -1,9 +1,9 @@
-import { GetStaticPaths, GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 import { AuthenticationRequired } from "../../components/AuthenticationRequired";
 import { TournamentRings } from "../../components/TournamentRings";
 import prisma from "../../lib/prisma";
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   let tournament = await prisma.tournament.findUnique({
     where: {
       id: params.id as string
@@ -57,15 +57,3 @@ export default function Tournament({ tournament, players, rings }) {
     </AuthenticationRequired>
   );
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const tournamentIds = await prisma.tournament.findMany({
-    select: { id: true }
-  });
-  return {
-    paths: tournamentIds.map((tournament) => ({
-      params: tournament
-    })),
-    fallback: false
-  };
-};

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -1,9 +1,33 @@
 import { GetServerSideProps } from "next";
+import { unstable_getServerSession } from "next-auth";
 import { AuthenticationRequired } from "../../components/AuthenticationRequired";
 import { TournamentRings } from "../../components/TournamentRings";
 import prisma from "../../lib/prisma";
+import { authConfig } from "../api/auth/[...nextauth]";
 
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+const isCurrentUserAuthorized = async (tournamentId, context) => {
+  const session = await unstable_getServerSession(
+    context.req,
+    context.res,
+    authConfig
+  );
+
+  const umpire = await prisma.umpire.findFirst({
+    where: {
+      userId: session.user.id,
+      tournamentId: tournamentId
+    }
+  });
+  return umpire != null;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  ...context
+}) => {
+  if (await !isCurrentUserAuthorized(params.id, context))
+    return { redirect: { destination: "/personal", permanent: false } };
+
   let tournament = await prisma.tournament.findUnique({
     where: {
       id: params.id as string

--- a/pages/api/tournament/rings.ts
+++ b/pages/api/tournament/rings.ts
@@ -1,9 +1,27 @@
 import prisma from "../../../lib/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { unstable_getServerSession } from "next-auth";
+import { authConfig } from "../auth/[...nextauth]";
+
+const isCurrentUserAuthorized = async (tournamentId, req, res) => {
+  const session = await unstable_getServerSession(req, res, authConfig);
+
+  const umpire = await prisma.umpire.findFirst({
+    where: {
+      userId: session.user.id,
+      tournamentId: tournamentId
+    }
+  });
+  return umpire;
+};
 
 export default async function rings(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
     const newRing = JSON.parse(req.body);
+    // TODO make a dynamic route to supply tournament id as path parameter and move this before method check
+    if (!isCurrentUserAuthorized(newRing.tournament, req, res)) {
+      res.status(403).end();
+    }
     const savedRing = await prisma.assignmentRing.create({
       data: {
         name: newRing.name,

--- a/pages/api/tournament/rings.ts
+++ b/pages/api/tournament/rings.ts
@@ -19,9 +19,11 @@ export default async function rings(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
     const newRing = JSON.parse(req.body);
     // TODO make a dynamic route to supply tournament id as path parameter and move this before method check
-    if (!isCurrentUserAuthorized(newRing.tournament, req, res)) {
+    if (!(await isCurrentUserAuthorized(newRing.tournament, req, res))) {
+      console.log("unauthorized!");
       res.status(403).end();
     }
+    console.log("authorized to create ring");
     const savedRing = await prisma.assignmentRing.create({
       data: {
         name: newRing.name,

--- a/pages/tournaments/[tournamentId]/players.tsx
+++ b/pages/tournaments/[tournamentId]/players.tsx
@@ -2,8 +2,35 @@ import Link from "next/link";
 import { GetServerSideProps } from "next";
 import prisma from "../../../lib/prisma";
 import { AuthenticationRequired } from "../../../components/AuthenticationRequired";
+import { unstable_getServerSession } from "next-auth";
+import { authConfig } from "../../api/auth/[...nextauth]";
 
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+const isCurrentUserAuthorized = async (tournamentId, context) => {
+  const session = await unstable_getServerSession(
+    context.req,
+    context.res,
+    authConfig
+  );
+
+  const umpire = await prisma.umpire.findFirst({
+    where: {
+      userId: session.user.id,
+      tournamentId: tournamentId
+    }
+  });
+  console.log("access check for tournament", tournamentId);
+  console.log("checking current user umpire status:", umpire);
+  return umpire != null;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  ...context
+}) => {
+  if (!(await isCurrentUserAuthorized(params.tournamentId, context))) {
+    console.log("is not authorized!");
+    return { redirect: { destination: "/personal", permanent: false } };
+  }
   const objects = await prisma.player.findMany({
     select: {
       id: true,

--- a/pages/tournaments/[tournamentId]/players.tsx
+++ b/pages/tournaments/[tournamentId]/players.tsx
@@ -36,7 +36,7 @@ export const getServerSideProps: GetServerSideProps = async ({
       id: true,
       alias: true,
       user: {
-        select: { firstName: true, lastName: true }
+        select: { id: true, firstName: true, lastName: true }
       }
     },
     where: {
@@ -61,13 +61,14 @@ export default function PlayerList({ objects }) {
             id: string;
             alias: string;
             user: {
+              id: string;
               firstName: string;
               lastName: string;
             };
           }) => {
             return (
               <li key={o.id}>
-                <Link href={`/tournaments/users/${o.id}`}>
+                <Link href={`/tournaments/users/${o.user.id}`}>
                   <a>
                     {o.user.firstName} {o.user.lastName} ({o.alias})
                   </a>

--- a/pages/tournaments/targets/[id].tsx
+++ b/pages/tournaments/targets/[id].tsx
@@ -27,12 +27,22 @@ const isCurrentUserAuthorized = async (targetId, context) => {
       userId: session.user.id
     }
   });
+
   const isHunter = await prisma.assignment.findFirst({
     where: {
-      hunterId: session.user.id,
-      targetId: targetId
+      target: {
+        user: {
+          id: targetId
+        }
+      },
+      hunter: {
+        user: {
+          id: session.user.id
+        }
+      }
     }
   });
+  console.log("assignment:", isHunter);
   return isUmpire || isHunter;
 };
 

--- a/pages/tournaments/targets/[id].tsx
+++ b/pages/tournaments/targets/[id].tsx
@@ -40,7 +40,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   params,
   ...context
 }) => {
-  if (await !isCurrentUserAuthorized(params.id, context))
+  if (!(await isCurrentUserAuthorized(params.id, context)))
     return { redirect: { destination: "/personal", permanent: false } };
 
   require("dotenv").config();

--- a/pages/tournaments/targets/[id].tsx
+++ b/pages/tournaments/targets/[id].tsx
@@ -12,8 +12,37 @@ import { Calendar } from "../../../components/Calendar";
 import Image from "next/image";
 import { Grid } from "@mui/material";
 import { AuthenticationRequired } from "../../../components/AuthenticationRequired";
+import { unstable_getServerSession } from "next-auth";
+import { authConfig } from "../../api/auth/[...nextauth]";
 
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+const isCurrentUserAuthorized = async (targetId, context) => {
+  const session = await unstable_getServerSession(
+    context.req,
+    context.res,
+    authConfig
+  );
+  // TODO add tournamentId to where clauses
+  const isUmpire = await prisma.umpire.findUnique({
+    where: {
+      userId: session.user.id
+    }
+  });
+  const isHunter = await prisma.assignment.findFirst({
+    where: {
+      hunterId: session.user.id,
+      targetId: targetId
+    }
+  });
+  return isUmpire || isHunter;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  ...context
+}) => {
+  if (await !isCurrentUserAuthorized(params.id, context))
+    return { redirect: { destination: "/personal", permanent: false } };
+
   require("dotenv").config();
   const cloudinary = require("cloudinary").v2;
   cloudinary.config({

--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -1,4 +1,4 @@
-import { GetStaticProps, GetStaticPaths } from "next";
+import { GetServerSideProps } from "next";
 import { Prisma, Tournament } from "@prisma/client";
 import { PlayerDetails } from "../../../components/PlayerDetails";
 import { PlayerContactInfo } from "../../../components/PlayerContactInfo";
@@ -13,7 +13,7 @@ import Image from "next/image";
 import { Grid } from "@mui/material";
 import { AuthenticationRequired } from "../../../components/AuthenticationRequired";
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   require("dotenv").config();
   const cloudinary = require("cloudinary").v2;
   cloudinary.config({
@@ -255,13 +255,3 @@ export default function UserInfo({ user, tournament, imageUrl }): JSX.Element {
     </AuthenticationRequired>
   );
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const userIds = await prisma.user.findMany({ select: { id: true } });
-  return {
-    paths: userIds.map((player) => ({
-      params: player
-    })),
-    fallback: false
-  };
-};

--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -39,7 +39,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   params,
   ...context
 }) => {
-  if (await !isCurrentUserAuthorized(params.id, context))
+  if (!(await isCurrentUserAuthorized(params.id, context)))
     return { redirect: { destination: "/personal", permanent: false } };
 
   require("dotenv").config();


### PR DESCRIPTION
Kaikki sivut paitsi ilmoittautuminen on nyt muutettu staattisista server-side-sivuiksi. `getServerSideProps`-funkkareihin on lisätty asiaankuuluvat sessiotarkistukset ja sama tehty myös API-sivuille.

Testaaminen suoritettu käsin kantaan luodun testiturnauksen avulla. Testattu tähän mennessä: 
* tuomarin pääsy omaan turnaukseensa
* tuomarin pääsy admin-sivulle
* tuomarin pääsyn estäminen muihin turnauksiin
* pelaajan pääsy omalle sivulleen
* pelaajan pääsy oman kohteensa sivulle
* pelaajan pääsyn esto muille pelaajasivuille
* pelaajan pääsyn esto muille kohdesivuille
* pelaajan pääsyn esto admin-sivuille