### PR TITLE
Show target page to player only when tournament is running

### DIFF
--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -19,7 +19,7 @@ import Image from "next/image";
 import logo from "/public/images/surma_logo.svg";
 import Link from "next/link";
 
-const NavigationBar = ({ targets, userId }) => {
+const NavigationBar = ({ targets, userId, tournamentId }) => {
   const [anchorElNav, setAnchorElNav] = React.useState(null);
 
   const [anchorElTarget, setAnchorElTarget] = React.useState(null);
@@ -116,7 +116,9 @@ const NavigationBar = ({ targets, userId }) => {
                     ) : (
                       targets.map((target, i) => (
                         <ListItemButton key={i} sx={{ pl: 4 }}>
-                          <Link href={`/tournaments/targets/${target.id}`}>
+                          <Link
+                            href={`/tournaments/${tournamentId}/targets/${target.id}`}
+                          >
                             <a>
                               {target.firstName} {target.lastName}
                             </a>
@@ -175,7 +177,9 @@ const NavigationBar = ({ targets, userId }) => {
               ) : (
                 targets.map((target) => (
                   <MenuItem key={target.id}>
-                    <Link href={`/tournaments/targets/${target.id}`}>
+                    <Link
+                      href={`/tournaments/${tournamentId}/targets/${target.id}`}
+                    >
                       <a>
                         {target.firstName} {target.lastName}
                       </a>

--- a/pages/tournaments/[tournamentId]/targets/[id].tsx
+++ b/pages/tournaments/[tournamentId]/targets/[id].tsx
@@ -1,19 +1,14 @@
 import { GetServerSideProps } from "next";
-import { Prisma, Tournament } from "@prisma/client";
-import { PlayerDetails } from "../../../components/PlayerDetails";
-import { PlayerContactInfo } from "../../../components/PlayerContactInfo";
-import prisma from "../../../lib/prisma";
-import React, { MouseEventHandler, useEffect } from "react";
+import { PlayerDetails } from "../../../../components/PlayerDetails";
+import { PlayerContactInfo } from "../../../../components/PlayerContactInfo";
+import prisma from "../../../../lib/prisma";
+import React, { MouseEventHandler } from "react";
 import { useState } from "react";
-import { UpdateForm } from "../../../components/UpdateForm";
-import { useRouter } from "next/router";
-import NavigationBar from "../../../components/NavigationBar";
-import { Calendar } from "../../../components/Calendar";
 import Image from "next/image";
 import { Grid } from "@mui/material";
-import { AuthenticationRequired } from "../../../components/AuthenticationRequired";
+import { AuthenticationRequired } from "../../../../components/AuthenticationRequired";
 import { unstable_getServerSession } from "next-auth";
-import { authConfig } from "../../api/auth/[...nextauth]";
+import { authConfig } from "../../../api/auth/[...nextauth]";
 
 const isCurrentUserAuthorized = async (targetId, context) => {
   const session = await unstable_getServerSession(
@@ -66,27 +61,27 @@ export const getServerSideProps: GetServerSideProps = async ({
   } catch (error) {
     console.log(error);
   }
-  const playerAsTarget: Prisma.PlayerSelect = {
-    address: true,
-    learningInstitution: true,
-    eyeColor: true,
-    hair: true,
-    height: true,
-    glasses: true,
-    other: true,
-    calendar: true,
-    user: {
-      select: {
-        firstName: true,
-        lastName: true
-      }
-    }
-  };
+
   const player = await prisma.player.findUnique({
     where: {
       userId: params.id as string
     },
-    select: playerAsTarget
+    select: {
+      address: true,
+      learningInstitution: true,
+      eyeColor: true,
+      hair: true,
+      height: true,
+      glasses: true,
+      other: true,
+      calendar: true,
+      user: {
+        select: {
+          firstName: true,
+          lastName: true
+        }
+      }
+    }
   });
   return {
     props: { player, imageUrl }

--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -98,7 +98,10 @@ export const getServerSideProps: GetServerSideProps = async ({
   });
   user = JSON.parse(JSON.stringify(user));
 
-  if (new Date().getTime() < new Date(tournament.startTime).getTime()) {
+  if (
+    user.player &&
+    new Date().getTime() < new Date(tournament.startTime).getTime()
+  ) {
     user.player.targets = [];
   }
   return {

--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -57,18 +57,6 @@ export const getServerSideProps: GetServerSideProps = async ({
     console.log(error);
   }
 
-  let tournament = await prisma.tournament.findFirst({
-    select: {
-      name: true,
-      startTime: true,
-      endTime: true,
-      registrationStartTime: true,
-      registrationEndTime: true,
-      players: true,
-      users: true
-    }
-  });
-  tournament = JSON.parse(JSON.stringify(tournament)); // avoid Next.js serialization error
   let user = await prisma.user.findUnique({
     where: {
       id: params.id as string
@@ -79,6 +67,7 @@ export const getServerSideProps: GetServerSideProps = async ({
       lastName: true,
       phone: true,
       email: true,
+      tournamentId: true,
       player: {
         select: {
           id: true,
@@ -96,6 +85,22 @@ export const getServerSideProps: GetServerSideProps = async ({
       }
     }
   });
+  let tournament = await prisma.tournament.findFirst({
+    select: {
+      name: true,
+      startTime: true,
+      endTime: true,
+      registrationStartTime: true,
+      registrationEndTime: true,
+      players: true,
+      users: true
+    },
+    where: {
+      id: user.tournamentId
+    }
+  });
+  tournament = JSON.parse(JSON.stringify(tournament)); // avoid Next.js serialization error
+
   user = JSON.parse(JSON.stringify(user));
 
   if (
@@ -261,7 +266,11 @@ export default function UserInfo({ user, tournament, imageUrl }): JSX.Element {
   return (
     <AuthenticationRequired>
       <div>
-        <NavigationBar targets={targetUsers} userId={user.id} />
+        <NavigationBar
+          targets={targetUsers}
+          userId={user.id}
+          tournamentId={user.tournamentId}
+        />
         <Grid container>
           <Grid item xs={12} md={5}>
             <div


### PR DESCRIPTION
Siirsin kohdesivut turnauksen dynaamisen polun alle, jotta turnaus-id:n sai helposti kaivettua. Vaati pientä veivaamista käyttäjäsivulla ja pienen muutoksen navigationbariin.