### PR TITLE
Manage player states

### DIFF
--- a/pages/api/player/[id].ts
+++ b/pages/api/player/[id].ts
@@ -1,0 +1,40 @@
+import prisma from "../../../lib/prisma";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { unstable_getServerSession } from "next-auth";
+import { authConfig } from "../auth/[...nextauth]";
+
+const isCurrentUserAuthorized = async (playerId, req, res) => {
+  const session = await unstable_getServerSession(req, res, authConfig);
+
+  const currentPlayer = await prisma.player.findFirst({
+    where: {
+      id: playerId,
+      userId: session.user.id
+    }
+  });
+  // TODO add tournamentId to where clause
+  const umpire = await prisma.umpire.findUnique({
+    where: {
+      userId: session.user.id
+    }
+  });
+  return currentPlayer || umpire;
+};
+
+export default async function update(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!isCurrentUserAuthorized(req.query.id, req, res)) {
+    res.status(403).end();
+  }
+  if (req.method === "PATCH") {
+    const playerId = req.query.id as string;
+    const playerData = JSON.parse(req.body);
+    const result = await prisma.player.update({
+      where: { userId: playerId },
+      data: playerData
+    });
+    res.status(204).end();
+  }
+}

--- a/pages/api/player/[id]/state.ts
+++ b/pages/api/player/[id]/state.ts
@@ -1,0 +1,43 @@
+import prisma from "../../../../lib/prisma";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { unstable_getServerSession } from "next-auth";
+import { authConfig } from "../../auth/[...nextauth]";
+
+const isCurrentUserAuthorized = async (playerId, req, res) => {
+  const session = await unstable_getServerSession(req, res, authConfig);
+
+  const updatedPlayer = await prisma.player.findFirst({
+    where: {
+      id: playerId,
+      userId: session.user.id
+    },
+    select: {
+      tournamentId: true
+    }
+  });
+  const umpire = await prisma.umpire.findFirst({
+    where: {
+      userId: session.user.id,
+      tournamentId: updatedPlayer.tournamentId
+    }
+  });
+  return umpire != null;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!isCurrentUserAuthorized(req.query.id, req, res)) {
+    res.status(403).end();
+  }
+  if (req.method === "PATCH") {
+    const playerId = req.query.id as string;
+    const { state } = JSON.parse(req.body);
+    const result = await prisma.player.update({
+      where: { userId: playerId },
+      data: { state }
+    });
+    res.status(204).end();
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,8 +51,15 @@ model Player {
   glasses             String?
   other               String?
   calendar            Json?
+  state               PlayerState  @default(ACTIVE)
   targets             Assignment[] @relation(name: "PlayerHasTarget")
   hunters             Assignment[] @relation(name: "PlayerIsHunted")
+}
+
+enum PlayerState {
+  ACTIVE
+  DEAD
+  DETECTIVE
 }
 
 model Umpire {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ enum PlayerState {
   ACTIVE
   DEAD
   DETECTIVE
+  EXTRA
 }
 
 model Umpire {


### PR DESCRIPTION
Lisätään pelaajalle kantaan sarake pelaajan tilalle, vaihtoehtoina nyt alkuun ACTIVE, DEAD, DETECTIVE ja EXTRA joista defaulttina ACTIVE. Lisäksi endpoint `PATCH /player/[id]/state`, jonka kautta tuomari voi muokata pelaajan tilaa.