### PR TITLE
Only allow whitelisted attributes on player update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "cloudinary": "^1.30.1",
         "dotenv": "^16.0.1",
         "formik": "^2.2.9",
+        "lodash": "^4.17.21",
         "next": "12.2.0",
         "next-auth": "^4.10.3",
         "next-ssl-redirect-middleware": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cloudinary": "^1.30.1",
     "dotenv": "^16.0.1",
     "formik": "^2.2.9",
+    "lodash": "^4.17.21",
     "next": "12.2.0",
     "next-auth": "^4.10.3",
     "next-ssl-redirect-middleware": "^0.1.4",

--- a/pages/api/user/update/[id].ts
+++ b/pages/api/user/update/[id].ts
@@ -41,11 +41,11 @@ export default async function update(
       "other",
       "calendar"
     ];
-    const updateData = JSON.parse(req.body);
+    const filteredUpdateData = _.pick(JSON.parse(req.body), allowedFields);
 
     const result = await prisma.player.update({
       where: { userId: playerId },
-      data: _.pick(updateData, allowedFields)
+      data: filteredUpdateData
     });
     res.status(204).end();
   }

--- a/pages/api/user/update/[id].ts
+++ b/pages/api/user/update/[id].ts
@@ -2,6 +2,7 @@ import prisma from "../../../../lib/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { unstable_getServerSession } from "next-auth";
 import { authConfig } from "../../auth/[...nextauth]";
+import _ from "lodash";
 
 const isCurrentUserAuthorized = async (playerId, req, res) => {
   const session = await unstable_getServerSession(req, res, authConfig);
@@ -30,10 +31,21 @@ export default async function update(
   }
   if (req.method === "PUT") {
     const playerId = req.query.id as string;
-    const playerData = JSON.parse(req.body);
+    const allowedFields = [
+      "address",
+      "learningInstitution",
+      "eyeColor",
+      "hair",
+      "height",
+      "glasses",
+      "other",
+      "calendar"
+    ];
+    const updateData = JSON.parse(req.body);
+
     const result = await prisma.player.update({
       where: { userId: playerId },
-      data: playerData
+      data: _.pick(updateData, allowedFields)
     });
     res.status(204).end();
   }


### PR DESCRIPTION
Päivitetään pelaajatiedoista vain eksplisiittisesti listatut kentät. Lodashin pick-funktio oli lopulta kivoin ratkaisu.