### PR TITLE
Fix calendar update error

### DIFF
--- a/pages/tournaments/users/[id].tsx
+++ b/pages/tournaments/users/[id].tsx
@@ -161,7 +161,7 @@ export default function UserInfo({
   let dates: Array<any> = [];
   dates.push(`${start.getDate()}.${start.getMonth() + 1}.`);
   let loopDay = start;
-  while (loopDay < end) {
+  while (loopDay.getDate() < end.getUTCDate()) {
     loopDay.setDate(loopDay.getDate() + 1);
     dates.push(`${loopDay.getDate()}.${loopDay.getMonth() + 1}.`);
   }


### PR DESCRIPTION
Tämän korjaaminen olikin paljon helpompaa kuin ajattelin: tarvitsi vain muuttaa turnauksen loppuaika UTC-ajaksi. Jos oikein ymmärsin, miten tämä toimii, niin vaikka tietokannassa kaikki näyttäisi olevan Suomen ajassa, koodissa tapahtuva date objectien muuttaminen stringeiksi ja takaisin sekoittaa vähän systeemiä ja lopulta turnauksen alkamis- ja päättymisajat ovat koodissa kolme tuntia tietokantaa edellä. Ongelma tämä on toki vain silloin kun turnaus päättyy lähellä keskiyötä, koska silloin loppuaika on koodissa eri päivänä kuin tietokannassa, ja kalenteria päivittäessä tietokantaan yritetään tunkea kalenteria, joka ei täysin vastaa tietokannassa olevaa kalenteria. Ei siis kovin kestävä ratkaisu tämä nykyinen koodi 😅 Pitää ehkä kehitellä joku vähän järkevämpi systeemi tämän hoitamiseen...

Olisin voinut myös tuon yhden rivin korjauksen pistää suoraan mainiin mutta olin jo ehtinyt tehdä uuden branchin tätä varten kun huomasin että vika on myös mainissa ja ajattelin että korjaamiseen varmaan tarvitaan useita muutoksia. 