### PR TITLE
Add detailsLastModified to Player

### DIFF
--- a/pages/api/user/update/[id].ts
+++ b/pages/api/user/update/[id].ts
@@ -45,7 +45,7 @@ export default async function update(
 
     const result = await prisma.player.update({
       where: { userId: playerId },
-      data: filteredUpdateData
+      data: { detailsLastModified: new Date(), ...filteredUpdateData }
     });
     res.status(204).end();
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model Player {
   createdAt           DateTime     @default(now()) @db.Timestamptz(3)
   modifiedAt          DateTime     @default(now()) @db.Timestamptz(3)
   lastVisit           DateTime?    @db.Timestamptz(3)
-  lastModified        DateTime?    @db.Timestamptz(3)
+  detailsLastModified DateTime?    @db.Timestamptz(3)
   userId              String       @unique
   user                User         @relation(fields: [userId], references: [id])
   tournament          Tournament   @relation(fields: [tournamentId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Player {
   createdAt           DateTime     @default(now()) @db.Timestamptz(3)
   modifiedAt          DateTime     @default(now()) @db.Timestamptz(3)
   lastVisit           DateTime?    @db.Timestamptz(3)
+  lastModified        DateTime?    @db.Timestamptz(3)
   userId              String       @unique
   user                User         @relation(fields: [userId], references: [id])
   tournament          Tournament   @relation(fields: [tournamentId], references: [id])


### PR DESCRIPTION
Lisätään pelaajan tietoihin `detailsLastModified`, jonka tarkoitus on merkitä viimeisintä ajanhetkeä, jolloin pelaaja on muokannut omia tietojaan tai kalenteriaan. Nimi voisi olla parempikin, mutta pelkkä `lastModified` olisi ollut tulkittavissa kattamaan mitkä tahansa muutokset Playeriin, ja nyt haluttiin nimenomaan ajankohta pelaajan itse tekemille muutoksille.