### PR TITLE
increase request body size limit to 10 mb for photo uploads

### DIFF
--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -1,6 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v2 as cloudinary } from "cloudinary";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "10mb"
+    }
+  }
+};
+
 export default async function upload(
   req: NextApiRequest,
   res: NextApiResponse


### PR DESCRIPTION
Kuvien lataaminen törmäsi tähän issueen: https://stackoverflow.com/questions/68574254/body-exceeded-1mb-limit-error-in-next-js-api-route