### PR TITLE
Send emails

### DIFF
--- a/pages/api/player/[id]/confirm.ts
+++ b/pages/api/player/[id]/confirm.ts
@@ -2,13 +2,14 @@ import prisma from "../../../../lib/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { unstable_getServerSession } from "next-auth";
 import { authConfig } from "../../auth/[...nextauth]";
+import sendEmail from "../../../../lib/ses_mailer";
 
 const isCurrentUserAuthorized = async (playerId, req, res) => {
   const session = await unstable_getServerSession(req, res, authConfig);
 
   const updatedPlayer = await prisma.player.findFirst({
     where: {
-      id: playerId,
+      id: playerId
     },
     select: {
       tournamentId: true
@@ -33,10 +34,27 @@ export default async function handler(
   if (req.method === "PATCH") {
     const playerId = req.query.id as string;
     const { confirmed } = JSON.parse(req.body);
+
+    const player = await prisma.player.findFirst({
+      where: {
+        id: playerId
+      },
+      include: {
+        user: true,
+        tournament: true
+      }
+    });
+
     const result = await prisma.player.update({
       where: { id: playerId },
       data: { confirmed }
     });
+    sendEmail(
+      "surma@salamurhaajat.net",
+      player.user.email,
+      `Ilmoittautumisesi on nyt vahvistettu!`,
+      `Tervetuloa mukaan Helsingin Yliopiston Salamurhaajien turnaukseen ${player.tournament.name}! Tuomaristo on tarkistanut ilmoittautumisesi ja vahvistanut sen.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin, vaan lähetä viestisi osoitteeseen tuomaristo@salamurhaajat.net`
+    );
     return res.status(200).send(result);
   }
 }

--- a/pages/api/player/[id]/confirm.ts
+++ b/pages/api/player/[id]/confirm.ts
@@ -53,7 +53,7 @@ export default async function handler(
       "surma@salamurhaajat.net",
       player.user.email,
       `Ilmoittautumisesi on nyt vahvistettu!`,
-      `Tervetuloa mukaan Helsingin Yliopiston Salamurhaajien turnaukseen ${player.tournament.name}! Tuomaristo on tarkistanut ilmoittautumisesi ja vahvistanut sen.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin, vaan lähetä viestisi osoitteeseen tuomaristo@salamurhaajat.net`
+      `Tervetuloa mukaan Helsingin Yliopiston Salamurhaajien turnaukseen ${player.tournament.name}! Tuomaristo on tarkistanut ilmoittautumisesi ja vahvistanut sen.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin. Tuomaristo vastaa peliin liittyviin viesteihin osoitteessa tuomaristo@salamurhaajat.net.`
     );
     return res.status(200).send(result);
   }

--- a/pages/api/player/create.ts
+++ b/pages/api/player/create.ts
@@ -1,42 +1,59 @@
 import prisma from "../../../lib/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
+import sendEmail from "../../../lib/ses_mailer";
 
 type PlayerFormData = {
-    userId: string
-    tournamentId: string
-    alias: string
-    address: string
-    learningInstitution?: string
-    eyeColor?: string
-    hair?: string
-    height?: string
-    other?: string
-    safetyNotes?: string
-    calendar?: object
-    title?: "LL" | "KK" | "MM" | "TT"
-}
+  userId: string;
+  tournamentId: string;
+  alias: string;
+  address: string;
+  learningInstitution?: string;
+  eyeColor?: string;
+  hair?: string;
+  height?: string;
+  other?: string;
+  safetyNotes?: string;
+  calendar?: object;
+  title?: "LL" | "KK" | "MM" | "TT";
+};
 
 export default async function create(
-    req: NextApiRequest,
-    res: NextApiResponse
-  ) {
-      const playerData: PlayerFormData = JSON.parse(req.body);
-      const result = await prisma.player.create({
-        data: {
-            user: { connect: { id: playerData.userId } },
-            tournament: { connect: { id: playerData.tournamentId } },
-            alias: playerData.alias,
-            address: playerData.address,
-            learningInstitution: playerData.learningInstitution,
-            eyeColor: playerData.eyeColor,
-            hair: playerData.hair,
-            height: parseInt(playerData.height),
-            other: playerData.other,
-            safetyNotes: playerData.safetyNotes,
-            calendar: playerData.calendar,
-            title: playerData.title
-        }
-      });
-      res.status(201).send(result);
-  }
-  
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const playerData: PlayerFormData = JSON.parse(req.body);
+  const user = await prisma.user.findFirst({
+    where: {
+      id: {
+        equals: playerData.userId
+      }
+    },
+    include: {
+      tournament: true
+    }
+  });
+
+  const result = await prisma.player.create({
+    data: {
+      user: { connect: { id: playerData.userId } },
+      tournament: { connect: { id: playerData.tournamentId } },
+      alias: playerData.alias,
+      address: playerData.address,
+      learningInstitution: playerData.learningInstitution,
+      eyeColor: playerData.eyeColor,
+      hair: playerData.hair,
+      height: parseInt(playerData.height),
+      other: playerData.other,
+      safetyNotes: playerData.safetyNotes,
+      calendar: playerData.calendar,
+      title: playerData.title
+    }
+  });
+  sendEmail(
+    "surma@salamurhaajat.net",
+    user.email,
+    "Kiitos ilmoittautumisestasi!",
+    `Tervetuloa mukaan Helsingin Yliopiston Salamurhaajien turnaukseen ${user.tournament.name}! Tuomaristo tarkistaa ilmoittautumisesi ja ottaa vielä yhteyttä ennen pelin alkua.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin, vaan lähetä viestisi osoitteeseen tuomaristo@salamurhaajat.net`
+  );
+  res.status(201).send(result);
+}

--- a/pages/api/player/create.ts
+++ b/pages/api/player/create.ts
@@ -54,7 +54,7 @@ export default async function create(
     "surma@salamurhaajat.net",
     user.email,
     "Kiitos ilmoittautumisestasi salamurhaturnaukseen ${user.tournament.name}!",
-    `Ilmoittautumisesi on nyt valmis! Tuomaristo tarkistaa sen vielä ennen pelin alkua, ja saat sähköpostitse vahvistusviestin kun ilmoittautumisesi on hyväksytty. Tuomaristo ottaa erikseen yhteyttä, mikäli antamiasi tietoja pitää täydentää tai muokata.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin, vaan lähetä viestisi osoitteeseen tuomaristo@salamurhaajat.net`
+    `Kiitos ilmoittautumisestasi! Tuomaristo tarkistaa ilmoittautumisesi vielä ennen pelin alkua, ja saat sähköpostitse vahvistusviestin, kun ilmoittautumisesi on hyväksytty. Tuomaristo ottaa erikseen yhteyttä, mikäli antamiasi tietoja pitää täydentää tai muokata.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin. Tuomaristo vastaa peliin liittyviin viesteihin osoitteessa tuomaristo@salamurhaajat.net.`
   );
   res.status(201).send(result);
 }

--- a/pages/api/player/create.ts
+++ b/pages/api/player/create.ts
@@ -52,8 +52,8 @@ export default async function create(
   sendEmail(
     "surma@salamurhaajat.net",
     user.email,
-    "Kiitos ilmoittautumisestasi!",
-    `Tervetuloa mukaan Helsingin Yliopiston Salamurhaajien turnaukseen ${user.tournament.name}! Tuomaristo tarkistaa ilmoittautumisesi ja ottaa vielä yhteyttä ennen pelin alkua.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin, vaan lähetä viestisi osoitteeseen tuomaristo@salamurhaajat.net`
+    "Kiitos ilmoittautumisestasi salamurhaturnaukseen ${user.tournament.name}!",
+    `Ilmoittautumisesi on nyt valmis! Tuomaristo tarkistaa sen vielä ennen pelin alkua, ja saat sähköpostitse vahvistusviestin kun ilmoittautumisesi on hyväksytty. Tuomaristo ottaa erikseen yhteyttä, mikäli antamiasi tietoja pitää täydentää tai muokata.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin, vaan lähetä viestisi osoitteeseen tuomaristo@salamurhaajat.net`
   );
   res.status(201).send(result);
 }

--- a/pages/api/user/create.ts
+++ b/pages/api/user/create.ts
@@ -29,7 +29,7 @@ export default async function create(
     sendEmail(
       "surma@salamurhaajat.net",
       "tuomaristo@salamurhaajat.net",
-      "Uusi ilmoittautuminen",
+      `${tournament.name}: Uusi ilmoittautuminen`,
       `${user.firstName} ${user.lastName} ilmoittautui mukaan turnaukseen ${tournament.name}.\n\n${playerUrl}`
     );
     res.status(201).send(user);

--- a/pages/api/user/create.ts
+++ b/pages/api/user/create.ts
@@ -29,7 +29,7 @@ export default async function create(
     sendEmail(
       "surma@salamurhaajat.net",
       "tuomaristo@salamurhaajat.net",
-      `${tournament.name}: Uusi ilmoittautuminen`,
+      `${tournament.name}: Uusi ilmoittautuminen (${user.firstName} ${user.lastName})`,
       `${user.firstName} ${user.lastName} ilmoittautui mukaan turnaukseen ${tournament.name}.\n\n${playerUrl}`
     );
     res.status(201).send(user);

--- a/pages/api/user/create.ts
+++ b/pages/api/user/create.ts
@@ -1,5 +1,6 @@
 import prisma from "../../../lib/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
+import sendEmail from "../../../lib/ses_mailer";
 
 export default async function create(
   req: NextApiRequest,
@@ -7,15 +8,30 @@ export default async function create(
 ) {
   if (req.method === "POST") {
     const playerData = JSON.parse(req.body);
-    const result = await prisma.user.create({
+    const tournament = await prisma.tournament.findFirst({
+      where: {
+        id: {
+          equals: playerData.tournamentId
+        }
+      }
+    });
+    const user = await prisma.user.create({
       data: {
         firstName: playerData.firstName,
         lastName: playerData.lastName,
         email: playerData.email,
         phone: playerData.phone,
-        tournament: { connect: { id: playerData.tournamentId } },
+        tournament: { connect: { id: playerData.tournamentId } }
       }
     });
-    res.status(201).send(result);
+
+    const playerUrl = `${process.env.BASE_URL}${playerData.tournamentId}/users/${user.id}`;
+    sendEmail(
+      "surma@salamurhaajat.net",
+      "tuomaristo@salamurhaajat.net",
+      "Uusi ilmoittautuminen",
+      `${user.firstName} ${user.lastName} ilmoittautui mukaan turnaukseen ${tournament.name}.\n\n${playerUrl}`
+    );
+    res.status(201).send(user);
   }
 }

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -10,6 +10,7 @@ import { v2 as cloudinary } from "cloudinary";
 import DesktopView from "../../../../components/PlayerPage/DesktopView";
 import MobileView from "../../../../components/PlayerPage/MobileView";
 import PlayerForm from "../../../../components/Registration/PlayerForm";
+import { useSession } from "next-auth/react";
 
 const isCurrentUserAuthorized = async (currentUser, userId, tournamentId) => {
   if (currentUser.id == userId) {
@@ -179,10 +180,11 @@ export default function User({
   const [confirmed, setConfirmed] = useState(
     user.player ? user.player.confirmed : false
   );
+  const { data } = useSession();
   const theme = useTheme();
   const isMobileView = useMediaQuery(theme.breakpoints.down("md"));
 
-  if (!Boolean(user.player) && currentUserIsUmpire) {
+  if (!Boolean(user.player) && user.id !== data.user.id) {
     return (
       <div style={{ margin: 2 }}>
         <h3>Pelaaja ei ole vielä täyttänyt ilmoittaumislomaketta loppuun</h3>

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -180,11 +180,11 @@ export default function User({
   const [confirmed, setConfirmed] = useState(
     user.player ? user.player.confirmed : false
   );
-  const { data } = useSession();
+  const session = useSession();
   const theme = useTheme();
   const isMobileView = useMediaQuery(theme.breakpoints.down("md"));
 
-  if (!Boolean(user.player) && user.id !== data.user.id) {
+  if (!Boolean(user.player) && user.id !== session.data.user.id) {
     return (
       <div style={{ margin: 2 }}>
         <h3>Pelaaja ei ole vielä täyttänyt ilmoittaumislomaketta loppuun</h3>

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -187,7 +187,8 @@ export default function User({
   if (!Boolean(user.player) && user.id !== session.data.user.id) {
     return (
       <div style={{ margin: 2 }}>
-        <h3>Pelaaja ei ole vielä täyttänyt ilmoittaumislomaketta loppuun</h3>
+        <h3>Pelaaja ei ole vielä täyttänyt tietojaan</h3>
+        ```
         <p>
           Nimi: {user.firstName} {user.lastName}
         </p>

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -182,6 +182,19 @@ export default function User({
   const theme = useTheme();
   const isMobileView = useMediaQuery(theme.breakpoints.down("md"));
 
+  if (!Boolean(user.player) && currentUserIsUmpire) {
+    return (
+      <div style={{ margin: 2 }}>
+        <h3>Pelaaja ei ole vielä täyttänyt ilmoittaumislomaketta loppuun</h3>
+        <p>
+          Nimi: {user.firstName} {user.lastName}
+        </p>
+        <p>Sähköpostiosoite: {user.email}</p>
+        <p>Puhelinnumero: {user.phone}</p>
+      </div>
+    );
+  }
+
   if (!Boolean(user.player)) {
     return <PlayerForm tournament={user.tournament} />;
   }


### PR DESCRIPTION
Korjataan sovelluksen sähköpostitoiminto, joka oli jossain vaiheessa otettu pois käytöstä. Nyt sähköposteja lähetetään kolmessa tilanteessa:
1. Tuomaristolle ilmoitetaan kun pelaaja on täyttänyt ensimmäisen ilmoittautumislomakkeen.
2. Pelaaja saa vahvistusviestin kun ilmoittautuminen on tehty loppuun.
3. Pelaaja saa vahvistusviestin kun tuomaristo on tarkistanut pelaajan ilmoittautumisen ja vahvistanut sen. 

Lisäksi lisäsin pelaajasivulle yksinkertaisen näkymän jossa näkyy ainoastaan pelaajan nimi, sähköposti ja puhelinnumero ja jonka tuomaristo näkee jos pelaaja ei ole tehnyt ilmoittautumistaan loppuun. 