### PR TITLE
Fix bug where player page crashes if session status is 'loading'

### DIFF
--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -184,6 +184,8 @@ export default function User({
   const theme = useTheme();
   const isMobileView = useMediaQuery(theme.breakpoints.down("md"));
 
+  if (session.status === "loading") return null;
+
   if (!Boolean(user.player) && user.id !== session.data.user.id) {
     return (
       <div style={{ margin: 2 }}>


### PR DESCRIPTION
Tosiaan huomasin bugin: jostain syystä viimeisimmät muutokset oli saanut aikaan sen, että pelaajasivu heittää errorin jos session status on "loading". Tässä yhden rivin fiksi, joka toivottavasti ratkaisee ongelman. 