### PR TITLE
Use backticks in email title string

### DIFF
--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -52,7 +52,7 @@ const NavigationBar = ({
 
   return (
     <AppBar position="static">
-      <Container maxWidth="xl" sx={{ backgroundColor: "#424242" }}>
+      <Container maxWidth={false} sx={{ backgroundColor: "#424242" }}>
         <Toolbar disableGutters>
           <Image src={logo} alt="logo" width={45} height={45} />
           <Typography

--- a/pages/api/player/create.ts
+++ b/pages/api/player/create.ts
@@ -53,7 +53,7 @@ export default async function create(
   sendEmail(
     "surma@salamurhaajat.net",
     user.email,
-    "Kiitos ilmoittautumisestasi salamurhaturnaukseen ${user.tournament.name}!",
+    `Kiitos ilmoittautumisestasi salamurhaturnaukseen ${user.tournament.name}!`,
     `Kiitos ilmoittautumisestasi! Tuomaristo tarkistaa ilmoittautumisesi vielä ennen pelin alkua, ja saat sähköpostitse vahvistusviestin, kun ilmoittautumisesi on hyväksytty. Tuomaristo ottaa erikseen yhteyttä, mikäli antamiasi tietoja pitää täydentää tai muokata.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin. Tuomaristo vastaa peliin liittyviin viesteihin osoitteessa tuomaristo@salamurhaajat.net.`
   );
   res.status(201).send(result);


### PR DESCRIPTION
Pari pientä korjausta
- Sähköpostin, joka pelaajalle lähetetään ilmolomakkeen täytön jälkeen, otsikossa oli väärät lainausmerkit, joten turnauksen nimi ei näkynyt oikein. 
- Navigaatiopalkin reunoille on ilmestynyt isoilla näytöillä siniset palkit. Nyt palkin leveys on korjattu.