### PR TITLE
Fix player url in registration email to umpires

### DIFF
--- a/pages/api/user/create.ts
+++ b/pages/api/user/create.ts
@@ -25,7 +25,7 @@ export default async function create(
       }
     });
 
-    const playerUrl = `${process.env.BASE_URL}${playerData.tournamentId}/users/${user.id}`;
+    const playerUrl = `${process.env.BASE_URL}tournaments/${playerData.tournamentId}/users/${user.id}`;
     sendEmail(
       "surma@salamurhaajat.net",
       "tuomaristo@salamurhaajat.net",

--- a/pages/api/user/create.ts
+++ b/pages/api/user/create.ts
@@ -25,7 +25,7 @@ export default async function create(
       }
     });
 
-    const playerUrl = `${process.env.BASE_URL}tournaments/${playerData.tournamentId}/users/${user.id}`;
+    const playerUrl = `${process.env.BASE_URL}/tournaments/${playerData.tournamentId}/users/${user.id}`;
     sendEmail(
       "surma@salamurhaajat.net",
       "tuomaristo@salamurhaajat.net",


### PR DESCRIPTION
Mailissa olleesta urlista oli jäänyt osa polusta pois, oikea endpoint on mallia `/tournaments/[turnaus-id]/users/[user-id]`.