### PR TITLE
Fix auth check error when user is not logged in (ie. currentUser is null)

### DIFF
--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -13,14 +13,12 @@ import PlayerForm from "../../../../components/Registration/PlayerForm";
 import { useSession } from "next-auth/react";
 
 const isCurrentUserAuthorized = async (currentUser, userId, tournamentId) => {
-  if (currentUser.id == userId) {
-    return true;
-  } else {
-    return (
+  return (
+    currentUser.id == userId ||
+    (currentUser != null &&
       currentUser.umpire != null &&
-      currentUser.umpire.tournamentId == tournamentId
-    );
-  }
+      currentUser.umpire.tournamentId == tournamentId)
+  );
 };
 
 export const getServerSideProps: GetServerSideProps = async ({


### PR DESCRIPTION
Kirjautumaton käyttäjä päätyi else-haaraan, jossa tarkastetaan, onko käyttäjä pelaajan turnauksen tuomari. Kirjautumattoman käyttäjän kohdalla `currentUser` on kuitenkin `null`, mikä aiheutti virheen umpire-kentän tarkastelussa. Lisätään currentUserin null-tarkistus ja samalla suoraviivaistetaan funktiota hieman.