### PR TITLE
Fix player images not showing in target page

### DIFF
--- a/components/PlayerPage/Info/ImageComponent.tsx
+++ b/components/PlayerPage/Info/ImageComponent.tsx
@@ -1,13 +1,7 @@
 import Image from "next/image";
 import { useState } from "react";
 
-const ImageComponent = ({
-  imageUrl,
-  setUpdateImage
-}: {
-  imageUrl: string;
-  setUpdateImage: any;
-}) => {
+const ImageComponent = ({ imageUrl }: { imageUrl: string }) => {
   const [showPicture, setShowPicture] = useState(false);
 
   return (
@@ -37,9 +31,6 @@ const ImageComponent = ({
           style={{ marginRight: "10px" }}
         >
           {showPicture ? "Piilota" : "Näytä kuva"}
-        </button>
-        <button onClick={() => setUpdateImage((prevState) => !prevState)}>
-          Vaihda kuva
         </button>
       </div>
     </div>

--- a/components/PlayerPage/Info/index.tsx
+++ b/components/PlayerPage/Info/index.tsx
@@ -67,7 +67,14 @@ const Info = ({ user, imageUrl, showStatusAndAlias, showImageForm }) => {
         )}
       </Box>
       {imageUrl && !updateImage ? (
-        <ImageComponent imageUrl={imageUrl} setUpdateImage={setUpdateImage} />
+        <>
+          <ImageComponent imageUrl={imageUrl} />
+          {showImageForm && (
+            <button onClick={() => setUpdateImage((prevState) => !prevState)}>
+              Vaihda kuva
+            </button>
+          )}
+        </>
       ) : !showImageForm ? (
         <p>{"Ei kuvaa :("}</p>
       ) : (

--- a/pages/tournaments/[tournamentId]/targets/[id].tsx
+++ b/pages/tournaments/[tournamentId]/targets/[id].tsx
@@ -160,7 +160,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   let imageUrl = "";
   try {
-    const result = await cloudinary.api.resource(params.id as string);
+    const result = await cloudinary.api.resource(user.player.id as string);
     imageUrl = result.url;
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
Tässä oli käynyt pieni moka. Pelaajien kuvat tallennetaan tietokantaan pelaajan id:llä mutta kohdesivulla kuvaa yritetään etsiä _käyttäjän_ id:llä. Onneksi ei ollut iso korjaus. Tein samalla sellaisen muutoksen, että jahtaajille ei näy Vaihda kuva -nappi. 