### PR TITLE
Normalize user email to lowercase for next-auth email login

### DIFF
--- a/pages/api/user/create.ts
+++ b/pages/api/user/create.ts
@@ -19,7 +19,7 @@ export default async function create(
       data: {
         firstName: playerData.firstName,
         lastName: playerData.lastName,
-        email: playerData.email,
+        email: playerData.email.toLowerCase(), // normalize user email for next-auth
         phone: playerData.phone,
         tournament: { connect: { id: playerData.tournamentId } }
       }


### PR DESCRIPTION
Lähtökohtaisesti next-auth [normalisoi käsittelemänsä email-osoitteet lowercaseksi](https://next-auth.js.org/providers/email#normalizing-the-email-address). Surman tapauksessa User-taulusta ja sen email-osoitteiden tallentamisesta vastaa kuitenkin oma ohjelmalogiikka. 

Tämä on johtanut ainakin kerran ongelmaan, jossa pelaajan email syötettiin ilmoittautuessa isolla alkukirjaimella, eikä kirjautuminen sitten toiminut, vaan kirjautumisikkuna sanoi "try signing in with a different account". Vastaavasti lowercasena tallennettua sähköpostiosoitetta vasten pystyy testatusti kirjautumaan myös isoilla kirjaimilla.

Paikataan siis tämä kirjautumisongelmalähde normalisoimalla Surman tallentamat email-osoitteet myös lowercaseksi.