### PR TITLE
normalize User emails in team creation

### DIFF
--- a/pages/api/team/create.ts
+++ b/pages/api/team/create.ts
@@ -22,7 +22,9 @@ export default async function create(
         name: teamName,
         users: {
           createMany: {
-            data: users
+            data: users.map((user) => {
+              return { ...user, email: user.email.toLowerCase() }; // normalize user email for next-auth
+            })
           }
         }
       },


### PR DESCRIPTION
Edellisessä [normalisointipularissa](https://github.com/hys-helsinki/surma/pull/131) jäi korjaamatta joukkueen luonnin yhteydessä tapahtuva User-luonti. Tehdään se nyt tässä.