### PR TITLE
Fix assignment deletion

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,6 +5,6 @@ export enum PlayerTitle {
   TT = "TT"
 }
 
-export const FeatureFlag = { DELETE_DEAD_PLAYER_ASSIGMENTS: false };
+export const FeatureFlag = { DELETE_DEAD_HUNTER_ASSIGNMENTS: false };
 
 export const TEAM_MAX_PLAYERS = 4;

--- a/pages/api/player/[id]/state.ts
+++ b/pages/api/player/[id]/state.ts
@@ -45,7 +45,7 @@ export default async function handler(
     });
 
     if (state === "DEAD") {
-      if (FeatureFlag.DELETE_DEAD_PLAYER_ASSIGMENTS) {
+      if (FeatureFlag.DELETE_DEAD_HUNTER_ASSIGNMENTS) {
         // teamGame-tarkistus, koska vuoden 2025 joukkueturnauksessa on käytössä erikoissääntö jossa kohteita ei heti poisteta kuolleilta pelaajilta.
         // Otetaan tarkistus pois turnauksen jälkeen jos näyttää siltä ettei erikoissääntöä jatkossa haluta käyttää joukkueturnauksissa.
 

--- a/pages/api/player/[id]/state.ts
+++ b/pages/api/player/[id]/state.ts
@@ -44,22 +44,32 @@ export default async function handler(
       }
     });
 
-    if (FeatureFlag.DELETE_DEAD_PLAYER_ASSIGMENTS && state === "DEAD") {
-      // teamGame-tarkistus, koska vuoden 2025 joukkueturnauksessa on käytössä erikoissääntö jossa kohteita ei heti poisteta kuolleilta pelaajilta.
-      // Otetaan tarkistus pois turnauksen jälkeen jos näyttää siltä ettei erikoissääntöä jatkossa haluta käyttää joukkueturnauksissa.
+    if (state === "DEAD") {
+      if (FeatureFlag.DELETE_DEAD_PLAYER_ASSIGMENTS) {
+        // teamGame-tarkistus, koska vuoden 2025 joukkueturnauksessa on käytössä erikoissääntö jossa kohteita ei heti poisteta kuolleilta pelaajilta.
+        // Otetaan tarkistus pois turnauksen jälkeen jos näyttää siltä ettei erikoissääntöä jatkossa haluta käyttää joukkueturnauksissa.
 
-      await prisma.assignment.deleteMany({
-        where: {
-          OR: [
-            {
-              hunterId: playerId
-            },
-            {
-              targetId: playerId
-            }
-          ]
-        }
-      });
+        await prisma.assignment.deleteMany({
+          where: {
+            OR: [
+              {
+                hunterId: playerId
+              },
+              {
+                targetId: playerId
+              }
+            ]
+          }
+        });
+      } else {
+        // Poistetaan joka tapauksessa pelaaja metsästäjien kohteista, koska muuten toimeksiannot pitää itse klikkailla pois kannasta.
+        // Ideana kuitenkin on, ettei kuollutta pelaajaa jahtaa enää kukaan.
+        await prisma.assignment.deleteMany({
+          where: {
+            targetId: playerId
+          }
+        });
+      }
     }
     res.json(updatedPlayer);
   }

--- a/pages/api/team-rings/delete.ts
+++ b/pages/api/team-rings/delete.ts
@@ -25,6 +25,12 @@ export default async function handler(
     res.status(403).end();
   }
 
+  await prisma.teamAssignment.deleteMany({
+    where: {
+      teamAssignmentRingId: data.ringId
+    }
+  });
+
   const deletedRing = await prisma.teamAssignmentRing.delete({
     where: {
       id: data.ringId


### PR DESCRIPTION
Nyt kun tässä turnausta on mennyt hetki niin huomasin, että eräs ominaisuus puuttuu ja ajattelin sen lisätä, jotta elämä on helpompaa. Tosiaan kun pelaaja merkitään kuolleeksi Surmassa, sen aikaisemmin tehdyn feature flagin takia mitään ei tapahdu. Olisi kuitenkin parempi, että joka tapauksessa poistetaan toimeksiannot, joissa pelaaja on kohteena, jotta kuollutta pelaajaa ei enää jahtaa kukaan. Tarkoituksena oli vain, että kuolleelle pelaajalle edelleen jää omat kohteet. Varsinkin nyt kun kyseessä on joukkueturnaus, niin Surmassa on vähän vaikeaa tehdä mitään pelaajakohtaisia toimeksiantojen poistoja, joten olen niitä tässä eilen ja tänään poistellut käsin kannasta.

Samalla huomasin että joukkuetoimeksiannot eivät poistu kun joukkuerinki poistetaan. En usko että rinkiä juurikaan kesken turnauksen tarvitsee poistaa mutta teinpä siihenkin tässä samalla nopean korjauksen. 