### PR TITLE
Update navbar_data and getServerSideProps data

### DIFF
--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -81,6 +81,8 @@ const NavigationBar = () => {
               marginRight: isMobileView ? 0 : "1rem"
             }}
           />
+
+          {/* Mobile */}
           <Typography
             variant="h6"
             noWrap
@@ -144,16 +146,12 @@ const NavigationBar = () => {
                     </ListItemButton>
                     <Collapse in={open} timeout="auto" unmountOnExit>
                       <List component="div" disablePadding>
-                        {targets.map((target) => (
-                          <ListItemButton
-                            key={target.target.user.id}
-                            sx={{ pl: 4 }}
-                          >
+                        {targets.map((user) => (
+                          <ListItemButton key={user.id} sx={{ pl: 4 }}>
                             <Link
-                              href={`/tournaments/${tournamentId}/targets/${target.target.user.id}`}
+                              href={`/tournaments/${tournamentId}/targets/${user.id}`}
                             >
-                              {target.target.user.firstName}{" "}
-                              {target.target.user.lastName}
+                              {user.firstName} {user.lastName}
                             </Link>
                           </ListItemButton>
                         ))}
@@ -182,6 +180,8 @@ const NavigationBar = () => {
               </List>
             </Menu>
           </Box>
+
+          {/* Desktop */}
           <Typography
             variant="h5"
             noWrap
@@ -222,12 +222,12 @@ const NavigationBar = () => {
               open={Boolean(anchorElTarget)}
               onClose={handleCloseTargetMenu}
             >
-              {targets.map((target) => (
-                <MenuItem key={target.target.user.id}>
+              {targets.map((user) => (
+                <MenuItem key={user.id}>
                   <Link
-                    href={`/tournaments/${tournamentId}/targets/${target.target.user.id}`}
+                    href={`/tournaments/${tournamentId}/targets/${user.id}`}
                   >
-                    {target.target.user.firstName} {target.target.user.lastName}
+                    {user.firstName} {user.lastName}
                   </Link>
                 </MenuItem>
               ))}

--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -21,13 +21,21 @@ import {
   MenuItem,
   List,
   ListItemButton,
-  ListItemText,
   Collapse
 } from "@mui/material";
+import { Player, Tournament, Umpire, User } from "@prisma/client";
+interface PlayerWithTargets extends Player {
+  targets: { id: string; firstName: string; lastName: string }[];
+}
+interface NavBarUser extends User {
+  player: PlayerWithTargets;
+  tournament: Tournament;
+  umpire: Umpire;
+}
 
 const NavigationBar = () => {
   const { data } = useSession();
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<NavBarUser>(null);
   const [anchorElNav, setAnchorElNav] = useState(null);
   const [anchorElTarget, setAnchorElTarget] = useState(null);
   const [open, setOpen] = useState(false);

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -45,12 +45,7 @@ export default async function handler(
         }
       },
       umpire: true,
-      tournament: {
-        select: {
-          startTime: true,
-          endTime: true
-        }
-      }
+      tournament: true
     }
   });
 
@@ -59,10 +54,10 @@ export default async function handler(
       new Date(user.tournament.startTime),
       new Date(user.tournament.endTime)
     ) && user.player
-      ? user.player.targets
+      ? user.player.targets.map((target) => target.target.user)
       : [];
 
-  user = { ...user, player: { ...user.player, targets } };
+  const responseData = { ...user, player: { ...user.player, targets } };
 
-  res.json(user);
+  res.json(responseData);
 }

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -57,7 +57,11 @@ export default async function handler(
       ? user.player.targets.map((target) => target.target.user)
       : [];
 
-  const responseData = { ...user, player: { ...user.player, targets } };
+  const uniqueTargets = targets.filter(
+    (value, index, self) => index === self.findIndex((t) => t.id === value.id)
+  );
+
+  const responseData = { ...user, player: { ...user.player, uniqueTargets } };
 
   res.json(responseData);
 }

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -54,12 +54,13 @@ export default async function handler(
     }
   });
 
-  const targets = isTournamentRunning(
-    new Date(user.tournament.startTime),
-    new Date(user.tournament.endTime)
-  )
-    ? user.player.targets
-    : [];
+  const targets =
+    isTournamentRunning(
+      new Date(user.tournament.startTime),
+      new Date(user.tournament.endTime)
+    ) && user.player
+      ? user.player.targets
+      : [];
 
   user = { ...user, player: { ...user.player, targets } };
 

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -58,7 +58,7 @@ export default async function handler(
       : [];
 
   const uniqueTargets = targets.filter(
-    (value, index, self) => index === self.findIndex((t) => t.id === value.id)
+    (value, index, array) => index === array.findIndex((t) => t.id === value.id)
   );
 
   const responseData = {

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -61,7 +61,10 @@ export default async function handler(
     (value, index, self) => index === self.findIndex((t) => t.id === value.id)
   );
 
-  const responseData = { ...user, player: { ...user.player, uniqueTargets } };
+  const responseData = {
+    ...user,
+    player: { ...user.player, targets: uniqueTargets }
+  };
 
   res.json(responseData);
 }

--- a/pages/tournaments/[tournamentId]/targets/[id].tsx
+++ b/pages/tournaments/[tournamentId]/targets/[id].tsx
@@ -79,22 +79,7 @@ export const getServerSideProps: GetServerSideProps = async ({
       umpire: true,
       player: {
         select: {
-          state: true,
-          targets: {
-            select: {
-              target: {
-                select: {
-                  user: {
-                    select: {
-                      id: true,
-                      firstName: true,
-                      lastName: true
-                    }
-                  }
-                }
-              }
-            }
-          }
+          state: true
         }
       }
     }
@@ -111,7 +96,7 @@ export const getServerSideProps: GetServerSideProps = async ({
       player: {
         select: {
           id: true,
-          alias: true,
+          alias: currentUser.player.state === "DETECTIVE" ? true : false,
           address: true,
           learningInstitution: true,
           eyeColor: true,
@@ -119,9 +104,7 @@ export const getServerSideProps: GetServerSideProps = async ({
           height: true,
           other: true,
           calendar: true,
-          lastVisit: true,
           title: true,
-          state: true,
           safetyNotes: true,
           umpire: {
             select: {
@@ -173,12 +156,6 @@ export const getServerSideProps: GetServerSideProps = async ({
       user,
       tournament,
       imageUrl,
-      targets: isTournamentRunning(
-        new Date(tournament.startTime),
-        new Date(tournament.endTime)
-      )
-        ? currentUser.player.targets
-        : [],
       currentUserIsUmpire: currentUser.umpire != null,
       currentUserIsDetective: currentUser.player.state === "DETECTIVE",
       umpires
@@ -191,21 +168,12 @@ export default function Target({
   currentUser,
   tournament,
   imageUrl,
-  targets = [],
   currentUserIsUmpire,
   currentUserIsDetective,
   umpires
 }): JSX.Element {
   const theme = useTheme();
   const isMobileView = useMediaQuery(theme.breakpoints.down("md"));
-
-  let targetUsers = [];
-
-  if (targets.length > 0) {
-    targetUsers = currentUser.player.targets.map(
-      (assignment) => assignment.target.user
-    );
-  }
 
   return (
     <AuthenticationRequired>

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -20,11 +20,6 @@ const isCurrentUserAuthorized = async (currentUser, userId, tournamentId) => {
   );
 };
 
-const isTournamentRunning = (startTime: Date, endTime: Date) => {
-  const currentTime = new Date().getTime();
-  return startTime.getTime() < currentTime && currentTime < endTime.getTime();
-};
-
 export const getServerSideProps: GetServerSideProps = async ({
   params,
   ...context
@@ -81,21 +76,6 @@ export const getServerSideProps: GetServerSideProps = async ({
           confirmed: true,
           state: true,
           safetyNotes: true,
-          targets: {
-            select: {
-              target: {
-                select: {
-                  user: {
-                    select: {
-                      id: true,
-                      firstName: true,
-                      lastName: true
-                    }
-                  }
-                }
-              }
-            }
-          },
           umpire: {
             select: {
               id: true,
@@ -157,12 +137,6 @@ export const getServerSideProps: GetServerSideProps = async ({
       user,
       tournament,
       imageUrl,
-      targets: isTournamentRunning(
-        new Date(tournament.startTime),
-        new Date(tournament.endTime)
-      )
-        ? user.player.targets
-        : [],
       currentUserIsUmpire: currentUser.umpire != null,
       umpires,
       currentUser
@@ -204,14 +178,6 @@ export default function User({
 
   if (!Boolean(user.player)) {
     return <PlayerForm tournament={user.tournament} />;
-  }
-
-  let targetUsers = [];
-
-  if (targets.length > 0) {
-    targetUsers = user.player.targets.map(
-      (assignment) => assignment.target.user
-    );
   }
 
   const handleConfirmRegistration = async () => {

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -148,7 +148,6 @@ export default function User({
   user,
   tournament,
   imageUrl,
-  targets = [],
   currentUserIsUmpire,
   umpires,
   currentUser


### PR DESCRIPTION
Korjasin muutaman bäkkäriin liittyvän ongelman:

- user- ja target-sivujen getServerSidePropsit siivottu sellaisesta datasta jota ei saa siellä olla. 
- navbar_dataan lisätty tuplakohteiden poisto.
- navbar_datan responsessa oleva targets oli hyvin ikävän muotoinen objekti niin sitä on nyt siistitty.
- navbar_datassa oli myös sellainen bugi, että jos turnaus on käynnissä ja kirjautunut käyttäjä on tuomari, kyseinen endpoint palauttaa virheen. Käytännössä ainoa vaikutus oli se, että tuomarit eivät nähneet navigointipalkissa linkkiä tuomarisivulle. Tästä ei kuitenkaan kukaan huomauttanut, joten en pitänyt kiirettä bugin korjaamisen kanssa. Mutta nyt on korjattu. 