### PR TITLE
Show lastVisit to players and add null check

### DIFF
--- a/components/PlayerPage/DesktopView.tsx
+++ b/components/PlayerPage/DesktopView.tsx
@@ -47,8 +47,7 @@ const DesktopView = ({
           />
           <Details
             umpires={umpires}
-            currentUserIsUmpire={currentUserIsUmpire}
-            currentUserIsHunter={currentUserIsHunter}
+            showPhoneAndEmail={currentUserIsUmpire || userId === currentUserId}
             setUser={setUser}
           />
         </Grid>

--- a/components/PlayerPage/Details/ContactDetails.tsx
+++ b/components/PlayerPage/Details/ContactDetails.tsx
@@ -3,32 +3,33 @@ import { useContext } from "react";
 import { UserContext } from "../../UserProvider";
 
 const ContactDetails = ({
-  showLastVisit
+  showPhoneAndEmail
 }: {
-  showLastVisit: boolean;
+  showPhoneAndEmail: boolean;
 }): JSX.Element => {
   const user = useContext(UserContext);
   return (
     <Box sx={{ my: 3 }}>
-      <h2>
-        <u>Yhteystiedot</u>
-      </h2>
-      <p>Puhelinnumero: {user.phone}</p>
-      <p>Sähköpostiosoite: {user.email}</p>
-
-      {showLastVisit && (
-        <p>
-          Viime vierailu:{" "}
-          {`${new Date(user.player.lastVisit).toLocaleTimeString("fi-FI", {
-            hour: "2-digit",
-            minute: "2-digit",
-            year: "numeric",
-            day: "numeric",
-            month: "numeric",
-            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
-          })}`}
-        </p>
+      {showPhoneAndEmail && (
+        <>
+          <h2>
+            <u>Yhteystiedot</u>
+          </h2>
+          <p>Puhelinnumero: {user.phone}</p>
+          <p>Sähköpostiosoite: {user.email}</p>
+        </>
       )}
+      <p>
+        Viime vierailu:{" "}
+        {`${new Date(user.player.lastVisit).toLocaleTimeString("fi-FI", {
+          hour: "2-digit",
+          minute: "2-digit",
+          year: "numeric",
+          day: "numeric",
+          month: "numeric",
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+        })}`}
+      </p>
     </Box>
   );
 };

--- a/components/PlayerPage/Details/ContactDetails.tsx
+++ b/components/PlayerPage/Details/ContactDetails.tsx
@@ -20,15 +20,17 @@ const ContactDetails = ({
         </>
       )}
       <p>
-        Viime vierailu:{" "}
-        {`${new Date(user.player.lastVisit).toLocaleTimeString("fi-FI", {
-          hour: "2-digit",
-          minute: "2-digit",
-          year: "numeric",
-          day: "numeric",
-          month: "numeric",
-          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
-        })}`}
+        Viime vierailu:
+        {user.player.lastVisit
+          ? ` ${new Date(user.player.lastVisit).toLocaleTimeString("fi-FI", {
+              hour: "2-digit",
+              minute: "2-digit",
+              year: "numeric",
+              day: "numeric",
+              month: "numeric",
+              timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+            })}`
+          : " pelaaja ei ole vieraillut Surmassa kirjautumisen jälkeen"}
       </p>
     </Box>
   );

--- a/components/PlayerPage/Details/index.tsx
+++ b/components/PlayerPage/Details/index.tsx
@@ -11,20 +11,16 @@ interface UmpireWithUser extends Umpire {
 
 const Details = ({
   umpires,
-  currentUserIsUmpire,
-  currentUserIsHunter,
+  showPhoneAndEmail,
   setUser
 }: {
   umpires: UmpireWithUser[];
-  currentUserIsUmpire: boolean;
-  currentUserIsHunter: boolean;
+  showPhoneAndEmail: boolean;
   setUser: Dispatch<any>;
 }) => {
   return (
     <Box>
-      {!currentUserIsHunter && (
-        <ContactDetails showLastVisit={currentUserIsUmpire} />
-      )}
+      <ContactDetails showPhoneAndEmail={showPhoneAndEmail} />
       <Umpires umpires={umpires} />
       <PlayerDescription setUser={setUser} />
     </Box>

--- a/components/PlayerPage/MobileView.tsx
+++ b/components/PlayerPage/MobileView.tsx
@@ -97,8 +97,7 @@ const MobileView = ({
       <TabPanel value={value} index={1}>
         <Details
           umpires={umpires}
-          currentUserIsUmpire={currentUserIsUmpire}
-          currentUserIsHunter={currentUserIsHunter}
+          showPhoneAndEmail={currentUserIsUmpire || userId === currentUserId}
           setUser={setUser}
         />
       </TabPanel>

--- a/pages/tournaments/[tournamentId]/targets/[id].tsx
+++ b/pages/tournaments/[tournamentId]/targets/[id].tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from "next";
 import prisma from "../../../../lib/prisma";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useMediaQuery, useTheme } from "@mui/material";
 import { AuthenticationRequired } from "../../../../components/AuthenticationRequired";
 import { Session, unstable_getServerSession } from "next-auth";
@@ -10,7 +10,6 @@ import DesktopView from "../../../../components/PlayerPage/DesktopView";
 import MobileView from "../../../../components/PlayerPage/MobileView";
 import { Tournament } from "@prisma/client";
 import { UserProvider } from "../../../../components/UserProvider";
-import { useRouter } from "next/router";
 import LoadingSpinner from "../../../../components/Common/LoadingSpinner";
 import { useRouterLoading } from "../../../../lib/hooks";
 
@@ -110,6 +109,7 @@ export const getServerSideProps: GetServerSideProps = async ({
           calendar: true,
           title: true,
           safetyNotes: true,
+          lastVisit: true,
           umpire: {
             select: {
               id: true,


### PR DESCRIPTION
Oli tuomariston kanssa puhetta, että lastVisitin voisi vaan näyttää kaikille pelaajille (sopii varsinkin tulevan turnauksen teemaan). Sain myös kuulla, että jos lastVisit on jostain syystä null - ainakin jos pelaaja ei ole käynyt Surmassa toisen ilmolomakkeen täytön jälkeen - niin viime vierailun kohdalla näkyy 1.1.1970. Sekin on nyt korjattu. 