### PR TITLE
Show loadingspinner when session is loading

### DIFF
--- a/components/AuthenticationRequired.tsx
+++ b/components/AuthenticationRequired.tsx
@@ -1,8 +1,11 @@
 import { signIn, useSession } from "next-auth/react";
+import LoadingSpinner from "./Common/LoadingSpinner";
 
 export const AuthenticationRequired = (props): JSX.Element => {
-  const { data: session } = useSession();
-  if (session) {
+  const { data: session, status } = useSession();
+
+  if (status === "loading") return <LoadingSpinner />;
+  else if (session) {
     return <>{props.children}</>;
   } else {
     return (

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -162,7 +162,7 @@ export default function User({
 
   const isLoading = useRouterLoading();
 
-  if (session.status === "loading" || isLoading) return <LoadingSpinner />;
+  if (isLoading) return <LoadingSpinner />;
 
   if (!Boolean(user.player) && user.id !== session.data.user.id) {
     return (


### PR DESCRIPTION
Kuulin pikkulinnuilta sellaista huhua, että kun pelaaja menee kohteidensa sivuille niin sivulla välähtää nopeasti "Et ole kirjautunut sisään"-teksti. Ei mitään kovin vakavaa siis mutta hieman häiritsee käyttökokemusta. Tein tällaisen nopean fiksin eli lisäsin AuthenticationRequired-komponenttiin if-lauseen, joka palauttaa LoadingSpinnerin jos session status on `loading`.