### PR TITLE
Fix user page crashing for umpires

### DIFF
--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -162,7 +162,7 @@ export default function User({
 
   const isLoading = useRouterLoading();
 
-  if (isLoading) return <LoadingSpinner />;
+  if (session.status === "loading" || isLoading) return <LoadingSpinner />;
 
   if (!Boolean(user.player) && user.id !== session.data.user.id) {
     return (


### PR DESCRIPTION
Pieni korjaus aikaisempaan pulariin: tarvitaan sittenkin tuo `session.status === "loading"`-tarkistus myös käyttäjäsivulle, koska sivu yrittää käyttää session `data`-objektia rivillä 167, vaikka on mahdollista, että data on `undefined`. Se aikaisempi pulari hajotti siis ainakin tuomareiden omat sivut. 