### PR TITLE
Miscellaneous improvements

### DIFF
--- a/components/Admin/PlayerTable.tsx
+++ b/components/Admin/PlayerTable.tsx
@@ -162,7 +162,7 @@ const PlayerTable = ({
   setRings: Dispatch<SetStateAction<RingWithAssignments[]>>;
   users: UmpirePageUser[];
 }) => {
-  if (players.length === 0) return <p>Ei pelaajia</p>;
+  if (users.length === 0) return <p>Ei pelaajia</p>;
 
   const sortedPlayers = players.sort((a, b) =>
     a.user.firstName.localeCompare(b.user.firstName)

--- a/components/Admin/Rings/PlayersWithTargets.tsx
+++ b/components/Admin/Rings/PlayersWithTargets.tsx
@@ -47,10 +47,10 @@ const PlayersWithTargets = ({
         .sort(
           (a, b) =>
             a.team?.name.localeCompare(b.team?.name) ||
-            a.user.firstName.localeCompare(b.user.firstName)
+            a.user.lastName.localeCompare(b.user.lastName)
         )
         .concat(players.filter((p) => !p.team))
-    : players.sort((a, b) => a.user.firstName.localeCompare(b.user.firstName));
+    : players.sort((a, b) => a.user.lastName.localeCompare(b.user.lastName));
   return (
     <>
       <h2>Pelaajien kohteet</h2>

--- a/components/Admin/TeamTable.tsx
+++ b/components/Admin/TeamTable.tsx
@@ -1,15 +1,8 @@
 import { Button, Grid } from "@mui/material";
-import { Player, Team, Tournament, User } from "@prisma/client";
+import { Tournament } from "@prisma/client";
 import Link from "next/link";
 import React, { useState } from "react";
-
-interface PlayerWithUser extends Player {
-  user: User;
-}
-
-interface TeamWithPlayers extends Team {
-  players: PlayerWithUser[];
-}
+import { UmpirePageTeam } from "../../types/umpirepage";
 
 const PlayerRow = ({ player: p, tournament, setRings }) => {
   const [player, setPlayer] = useState(p);
@@ -116,7 +109,7 @@ const TeamTable = ({
   setRings
 }: {
   tournament: Tournament;
-  teams: TeamWithPlayers[];
+  teams: UmpirePageTeam[];
   users: any[];
   setRings: any;
 }) => {

--- a/components/Admin/UmpireSelect.tsx
+++ b/components/Admin/UmpireSelect.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Grid, Snackbar } from "@mui/material";
+import { Alert, Box, Button, Grid, Snackbar } from "@mui/material";
 import { Field, Form, Formik } from "formik";
 import { Dispatch, SetStateAction, useState } from "react";
 import { UmpirePagePlayer, UmpirePageUser } from "../../types/umpirepage";
@@ -94,9 +94,16 @@ const UmpireSelect = ({
             <Snackbar
               open={showSuccessText}
               onClose={() => setShowSuccessText(false)}
-              autoHideDuration={4000}
-              message="Tuomarien asettaminen onnistui!"
-            />
+            >
+              <Alert
+                severity="success"
+                variant="filled"
+                sx={{ width: "100%" }}
+                onClose={() => setShowSuccessText(false)}
+              >
+                Tuomarien asettaminen onnistui!
+              </Alert>
+            </Snackbar>
           </Form>
         </Formik>
       </Grid>

--- a/components/Admin/WantedModal.tsx
+++ b/components/Admin/WantedModal.tsx
@@ -1,14 +1,8 @@
-import { Box, Modal, Snackbar, Button } from "@mui/material";
-import { Assignment, Player, Team, User } from "@prisma/client";
+import { Box, Modal, Snackbar, Button, Alert } from "@mui/material";
 import { Formik, Form, Field } from "formik";
 import { getPlayerFullNameById } from "../utils";
 import { useState } from "react";
-
-interface PlayerWithUser extends Player {
-  user: User;
-  targets: Assignment[];
-  team?: Team;
-}
+import { UmpirePagePlayer } from "../../types/umpirepage";
 
 const style = {
   position: "absolute" as "absolute",
@@ -33,7 +27,7 @@ const WantedModal = ({
   setOpenModal,
   tournament
 }: {
-  players: PlayerWithUser[];
+  players: UmpirePagePlayer[];
   wantedPlayerId: string;
   open: boolean;
   setRings: any;
@@ -106,11 +100,14 @@ const WantedModal = ({
                     Keille etsiville annat kohteeksi pelaajan {wantedPlayerName}
                     ?
                   </p>
-                  <Box>
-                    <button type="button" onClick={handleSelectAll}>
-                      {allSelected ? "Tyhjennä" : "Valitse kaikki"}
-                    </button>
-                  </Box>
+                  {detectivePlayers.length === 0 && <i>Ei etsiviä :(</i>}
+                  {detectivePlayers.length > 0 && (
+                    <Box>
+                      <button type="button" onClick={handleSelectAll}>
+                        {allSelected ? "Tyhjennä" : "Valitse kaikki"}
+                      </button>
+                    </Box>
+                  )}
                   {detectivePlayers.map((player) => (
                     <Box
                       sx={{
@@ -134,7 +131,14 @@ const WantedModal = ({
                     </Box>
                   ))}
 
-                  <Button type="submit" loading={isLoading}>
+                  <Button
+                    type="submit"
+                    loading={isLoading}
+                    disabled={
+                      detectivePlayers.length === 0 ||
+                      values.selectedPlayers.length === 0
+                    }
+                  >
                     Etsintäkuuluta
                   </Button>
                   <button onClick={() => setOpenModal(false)}>Peruuta</button>
@@ -150,6 +154,19 @@ const WantedModal = ({
         autoHideDuration={4000}
         message="Etsintäkuuluttaminen onnistui!"
       />
+      <Snackbar
+        open={showSuccessText}
+        onClose={() => setShowSuccessText(false)}
+      >
+        <Alert
+          severity="success"
+          variant="filled"
+          sx={{ width: "100%" }}
+          onClose={() => setShowSuccessText(false)}
+        >
+          Etsintäkuuluttaminen onnistui!
+        </Alert>
+      </Snackbar>
     </>
   );
 };

--- a/components/Admin/WantedModal.tsx
+++ b/components/Admin/WantedModal.tsx
@@ -152,11 +152,6 @@ const WantedModal = ({
         open={showSuccessText}
         onClose={() => setShowSuccessText(false)}
         autoHideDuration={4000}
-        message="Etsintäkuuluttaminen onnistui!"
-      />
-      <Snackbar
-        open={showSuccessText}
-        onClose={() => setShowSuccessText(false)}
       >
         <Alert
           severity="success"

--- a/components/Common/Markdown.tsx
+++ b/components/Common/Markdown.tsx
@@ -1,29 +1,31 @@
 /* Thanks Toska for the code :D */
 
-import React from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkBreaks from 'remark-breaks'
-import { Link, Typography } from '@mui/material'
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
+import { Link, Typography } from "@mui/material";
 
-const GutterTypography = ({ ...rest }) => <Typography {...rest} />
+const GutterTypography = ({ ...rest }) => (
+  <Typography {...rest} style={{ overflowWrap: "break-word" }} />
+);
 
 const H1 = ({ ...rest }) => (
   <GutterTypography variant="h4" component="h1" {...rest} />
-)
+);
 
 const H2 = ({ ...rest }) => (
   <GutterTypography variant="h5" component="h2" {...rest} />
-)
+);
 
 const H3 = ({ ...rest }) => (
   <GutterTypography variant="h6" component="h3" {...rest} />
-)
+);
 
 const H4 = ({ ...rest }) => (
   <GutterTypography variant="body1" component="h4" {...rest} />
-)
+);
 
-const A = ({ ...rest }) => <Link color="inherit" {...rest} />
+const A = ({ ...rest }) => <Link color="inherit" {...rest} />;
 
 const defaultComponents = {
   p: GutterTypography,
@@ -31,17 +33,18 @@ const defaultComponents = {
   h1: H1,
   h2: H2,
   h3: H3,
-  h4: H4,
-}
+  h4: H4
+};
 
-interface MarkdownProps {
-  children: string
+interface MarkdownProps
+  extends Omit<React.ComponentProps<typeof ReactMarkdown>, "children"> {
+  children: string;
 }
 
 const Markdown = ({ children, ...props }: MarkdownProps) => {
-  if (!children) return null
+  if (!children) return null;
 
-  const content = children.replace(/\n/gi, '&nbsp; \n')
+  const content = children.replace(/\n/gi, "&nbsp; \n");
 
   return (
     <ReactMarkdown
@@ -51,7 +54,7 @@ const Markdown = ({ children, ...props }: MarkdownProps) => {
     >
       {content}
     </ReactMarkdown>
-  )
-}
+  );
+};
 
-export default Markdown
+export default Markdown;

--- a/components/Common/TextInput.tsx
+++ b/components/Common/TextInput.tsx
@@ -2,16 +2,18 @@ import { useField } from "formik";
 
 const TextInput = ({ label, ...props }) => {
   const [field, meta] = useField(props.name);
+
+  const { textArea, ...inputProps } = props;
   return (
     <div style={{ marginBottom: "7px" }}>
-      <label htmlFor={props.id}>{label}</label>
+      <label htmlFor={inputProps.id}>{label}</label>
       {meta.touched && meta.error ? (
         <div className="registration-error">{meta.error}</div>
       ) : null}
-      {props.textArea ? (
-        <textarea {...field} {...props} />
+      {textArea ? (
+        <textarea {...field} {...inputProps} />
       ) : (
-        <input {...field} {...props} />
+        <input {...field} {...inputProps} />
       )}
     </div>
   );

--- a/components/PlayerPage/Calendar.tsx
+++ b/components/PlayerPage/Calendar.tsx
@@ -106,24 +106,12 @@ export const Calendar = ({
             }}
           >
             {weekNumber > 0 && (
-              <button
-                onClick={() =>
-                  setSlideNumber(
-                    weekNumber > 0 ? weekNumber - 1 : weeks.length - 1
-                  )
-                }
-              >
+              <button onClick={() => setSlideNumber(weekNumber - 1)}>
                 {t("playerPage.calendar.previousButton")}
               </button>
             )}
             {weekNumber < weeks.length - 1 && (
-              <button
-                onClick={() =>
-                  setSlideNumber(
-                    weekNumber < weeks.length - 1 ? weekNumber + 1 : 0
-                  )
-                }
-              >
+              <button onClick={() => setSlideNumber(weekNumber + 1)}>
                 {t("playerPage.calendar.nextButton")}
               </button>
             )}

--- a/components/PlayerPage/Calendar.tsx
+++ b/components/PlayerPage/Calendar.tsx
@@ -46,14 +46,6 @@ export const Calendar = ({
 
   if (weeks.length === 0) return null;
 
-  const handleSlideShow = () => {
-    if (weekNumber == weeks.length - 1) {
-      setSlideNumber(0);
-    } else {
-      setSlideNumber(weekNumber + 1);
-    }
-  };
-
   const handleCalendarSubmit = async (values) => {
     setIsLoading(true);
     const updatedCalendar: string[][] = dates.map((date, index) => [
@@ -106,9 +98,36 @@ export const Calendar = ({
               </li>
             ))}
           </ul>
-          <button onClick={() => handleSlideShow()} style={{ left: "40%" }}>
-            {t("playerPage.calendar.nextButton")}
-          </button>
+          <div
+            style={{
+              display: "flex",
+              gap: "20px",
+              margin: "0"
+            }}
+          >
+            {weekNumber > 0 && (
+              <button
+                onClick={() =>
+                  setSlideNumber(
+                    weekNumber > 0 ? weekNumber - 1 : weeks.length - 1
+                  )
+                }
+              >
+                {t("playerPage.calendar.previousButton")}
+              </button>
+            )}
+            {weekNumber < weeks.length - 1 && (
+              <button
+                onClick={() =>
+                  setSlideNumber(
+                    weekNumber < weeks.length - 1 ? weekNumber + 1 : 0
+                  )
+                }
+              >
+                {t("playerPage.calendar.nextButton")}
+              </button>
+            )}
+          </div>
         </div>
       ) : (
         <Formik

--- a/components/PlayerPage/Details/PlayerDescription.tsx
+++ b/components/PlayerPage/Details/PlayerDescription.tsx
@@ -4,6 +4,7 @@ import { Dispatch, useContext, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { UserContext } from "../../UserProvider";
 import { useSession } from "next-auth/react";
+import Markdown from "../../Common/Markdown";
 
 const PlayerDescription = ({ setUser }: { setUser: Dispatch<any> }) => {
   const { t } = useTranslation("common");
@@ -27,66 +28,71 @@ const PlayerDescription = ({ setUser }: { setUser: Dispatch<any> }) => {
         )}
         {!isUpdating ? (
           <Box>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center"
-              }}
-            >
-              <b
+            <div>
+              <div
                 style={{
-                  color: "orange",
-                  fontSize: "xxx-large"
+                  display: "flex",
+                  alignItems: "center"
                 }}
+                className="safety-notes-label"
               >
-                !
-              </b>
-              <b>{t("playerPage.details.description.safetyNotesTitle")}</b>
-            </div>
-            <pre
-              style={{
-                whiteSpace: "pre-wrap",
-                margin: "auto",
-                width: "100%",
-                overflowWrap: "break-word"
-              }}
-            >
-              {player.safetyNotes}
-            </pre>
+                <b
+                  style={{
+                    color: "orange",
+                    fontSize: "xxx-large"
+                  }}
+                >
+                  !
+                </b>
+                <h3>{t("playerPage.details.description.safetyNotesTitle")}</h3>
+              </div>
 
-            <p>
-              <b>{t("playerPage.details.description.addressLabel")}:</b>{" "}
-              {player.address}
-            </p>
-            <p>
-              <b>
+              <Markdown className="safety-notes-contents">
+                {player.safetyNotes}
+              </Markdown>
+            </div>
+            <div>
+              <h3 className="address-label">
+                {t("playerPage.details.description.addressLabel")}:
+              </h3>
+              <Markdown className="address-contents">{player.address}</Markdown>
+            </div>
+            <div>
+              <h3 className="learning-institution">
                 {t("playerPage.details.description.learningInstitutionLabel")}:
-              </b>{" "}
-              {player.learningInstitution}
-            </p>
-            <p>
-              <b>{t("playerPage.details.description.eyeColorLabel")}:</b>{" "}
-              {player.eyeColor}
-            </p>
-            <p>
-              <b>{t("playerPage.details.description.hairLabel")}:</b>{" "}
-              {player.hair}
-            </p>
-            <p>
-              <b>{t("playerPage.details.description.heightLabel")}:</b>{" "}
-              {player.height}
-            </p>
-            <b>{t("playerPage.details.description.otherInfoLabel")}</b>
-            <pre
-              style={{
-                whiteSpace: "pre-wrap",
-                margin: "auto",
-                width: "100%",
-                overflowWrap: "break-word"
-              }}
-            >
-              {player.other}
-            </pre>
+              </h3>{" "}
+              <Markdown className="learning-institution-contents">
+                {player.learningInstitution}
+              </Markdown>
+            </div>
+            <div>
+              <h3 className="eye-color-label">
+                {t("playerPage.details.description.eyeColorLabel")}:
+              </h3>{" "}
+              <Markdown className="eye-color-contents">
+                {player.eyeColor}
+              </Markdown>
+            </div>
+            <div>
+              <h3 className="hair-label">
+                {t("playerPage.details.description.hairLabel")}:
+              </h3>{" "}
+              <Markdown className="hair-contents">{player.hair}</Markdown>
+            </div>
+            <div>
+              <h3 className="height-label">
+                {t("playerPage.details.description.heightLabel")}:
+              </h3>{" "}
+              <Markdown className="height-contents">{player.height}</Markdown>
+            </div>
+            <div>
+              <h3 className="other-info-label">
+                {t("playerPage.details.description.otherInfoLabel")}{" "}
+              </h3>
+              <Markdown className="other-info-contents">
+                {player.other}
+              </Markdown>
+            </div>
           </Box>
         ) : (
           <UpdateForm setUser={setUser} setIsUpdating={setIsUpdating} />

--- a/components/PlayerPage/Details/UpdateForm.tsx
+++ b/components/PlayerPage/Details/UpdateForm.tsx
@@ -61,6 +61,9 @@ export const UpdateForm = ({
       }}
     >
       <Form>
+        <p>
+          <i>{t("playerPage.details.updateForm.markdownNote")}</i>
+        </p>
         <TextInput
           label={t("playerPage.details.updateForm.safetyNotesLabel")}
           name="safetyNotes"

--- a/components/PlayerPage/Info/index.tsx
+++ b/components/PlayerPage/Info/index.tsx
@@ -41,7 +41,7 @@ const Info = ({
         }}
       >
         <h1>
-          {user.player.title} {user.firstName} {user.lastName}
+          {user.firstName} {user.lastName}
         </h1>
 
         {showAlias && (

--- a/components/Registration/PlayerForm/PlayerDetailsForm.tsx
+++ b/components/Registration/PlayerForm/PlayerDetailsForm.tsx
@@ -79,11 +79,16 @@ const PlayerDetailsForm = ({
           autoComplete="home"
           type="text"
         />
-        <Box sx={{ marginBottom: "8px" }}>
+        <Box sx={{ my: 1 }}>
           <div style={{ width: "100%" }}>
             <label htmlFor="title">{t("playerForm.professionalTitle")}</label>
           </div>
-          <Field name="title" id="title" as="select">
+          <Field
+            name="title"
+            id="title"
+            as="select"
+            style={{ margin: "8px 0" }}
+          >
             <option>{t("playerForm.noTitle")}</option>
             <option value={PlayerTitle.KK}>{PlayerTitle.KK}</option>
             <option value={PlayerTitle.MM}>{PlayerTitle.MM}</option>

--- a/components/Registration/PlayerForm/PlayerDetailsForm.tsx
+++ b/components/Registration/PlayerForm/PlayerDetailsForm.tsx
@@ -43,7 +43,7 @@ const PlayerDetailsForm = ({
   }));
   const initialFields = {
     alias: "",
-    title: undefined,
+    title: "",
     address: "",
     learningInstitution: "",
     eyeColor: "",
@@ -89,7 +89,7 @@ const PlayerDetailsForm = ({
             as="select"
             style={{ margin: "8px 0" }}
           >
-            <option>{t("playerForm.noTitle")}</option>
+            <option value="">{t("playerForm.noTitle")}</option>
             <option value={PlayerTitle.KK}>{PlayerTitle.KK}</option>
             <option value={PlayerTitle.MM}>{PlayerTitle.MM}</option>
             <option value={PlayerTitle.LL}>{PlayerTitle.LL}</option>

--- a/components/Registration/PlayerForm/index.tsx
+++ b/components/Registration/PlayerForm/index.tsx
@@ -72,7 +72,7 @@ export default function PlayerForm({
       learningInstitution,
       other,
       safetyNotes,
-      title,
+      title: title != "" ? title : undefined,
       calendar
     };
 

--- a/components/Registration/PlayerForm/index.tsx
+++ b/components/Registration/PlayerForm/index.tsx
@@ -83,7 +83,13 @@ export default function PlayerForm({
       });
       const responseObject = await response.json();
       if (response.status === 200) {
-        setUser((prev) => ({ ...prev, player: responseObject.player }));
+        setUser((prev) => ({
+          ...prev,
+          firstName: playerData.title
+            ? `${playerData.title} ${prev.firstName}`
+            : prev.firstName,
+          player: responseObject.player
+        }));
       } else {
         setFormErrorMessage(t("playerForm.error"));
         setShowFormError(true);

--- a/components/Registration/UserForm.tsx
+++ b/components/Registration/UserForm.tsx
@@ -49,7 +49,7 @@ const UserForm = ({ tournament }: { tournament: Tournament }) => {
 
   return (
     <Container maxWidth="md">
-      <h1 style={{ marginLeft: "10px" }}>{t("registration.userForm.title")}</h1>
+      <h1>{t("registration.userForm.title")}</h1>
 
       <Box sx={{ my: 4 }}>
         <p>

--- a/components/UmpirePage/Settings.tsx
+++ b/components/UmpirePage/Settings.tsx
@@ -11,10 +11,7 @@ import * as Yup from "yup";
 import { useRouter } from "next/router";
 import { Tooltip, Button } from "@mui/material";
 import { useSession } from "next-auth/react";
-
-interface UmpireUser extends User {
-  umpire: Umpire;
-}
+import { UmpirePageUser } from "../../types/umpirepage";
 
 const DateTimePicker = ({ label, name }) => {
   const [field, meta, helpers] = useField(name);
@@ -172,6 +169,7 @@ const DeleteButton = ({ tournament }: { tournament: Tournament }) => {
             loading={loading}
             className="delete-tournament"
             disabled={!isTournamentFinished()}
+            sx={{ backgroundColor: "#a50000", color: "white" }}
           >
             Poista kaikki turnausdata
           </Button>
@@ -186,7 +184,7 @@ const Settings = ({
   umpireUsers
 }: {
   tournament: Tournament;
-  umpireUsers: UmpireUser[];
+  umpireUsers: UmpirePageUser[];
 }) => {
   const session = useSession();
 

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -210,14 +210,6 @@ export default function UmpirePage({
   const [players, setPlayers] = useState<UmpirePagePlayer[]>(playerList);
   const [value, setValue] = useState(0);
 
-  const playersWithTitles = players.map((p) => ({
-    ...p,
-    user: {
-      ...p.user,
-      firstName: p.title ? `${p.title} ${p.user.firstName}` : p.user.firstName
-    }
-  }));
-
   const isLoading = useRouterLoading();
   if (isLoading) return <LoadingSpinner />;
 
@@ -260,7 +252,7 @@ export default function UmpirePage({
             />
           ) : (
             <PlayerTable
-              players={playersWithTitles}
+              players={players}
               setPlayers={setPlayers}
               tournament={tournament}
               setRings={setRings}
@@ -271,14 +263,14 @@ export default function UmpirePage({
         <TabPanel value={value} index={2}>
           <UmpireSelect
             umpires={umpires}
-            players={playersWithTitles}
+            players={players}
             tournament={tournament}
             setPlayers={setPlayers}
           />
         </TabPanel>
         <TabPanel value={value} index={1}>
           <Rings
-            players={playersWithTitles}
+            players={players}
             playerRings={playerRings}
             teamRings={teamRings}
             setTeamRings={setTeamRings}

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -210,6 +210,14 @@ export default function UmpirePage({
   const [players, setPlayers] = useState<UmpirePagePlayer[]>(playerList);
   const [value, setValue] = useState(0);
 
+  const playersWithTitles = players.map((p) => ({
+    ...p,
+    user: {
+      ...p.user,
+      firstName: p.title ? `${p.title} ${p.user.firstName}` : p.user.firstName
+    }
+  }));
+
   const isLoading = useRouterLoading();
   if (isLoading) return <LoadingSpinner />;
 
@@ -252,7 +260,7 @@ export default function UmpirePage({
             />
           ) : (
             <PlayerTable
-              players={players}
+              players={playersWithTitles}
               setPlayers={setPlayers}
               tournament={tournament}
               setRings={setRings}
@@ -263,14 +271,14 @@ export default function UmpirePage({
         <TabPanel value={value} index={2}>
           <UmpireSelect
             umpires={umpires}
-            players={players}
+            players={playersWithTitles}
             tournament={tournament}
             setPlayers={setPlayers}
           />
         </TabPanel>
         <TabPanel value={value} index={1}>
           <Rings
-            players={players}
+            players={playersWithTitles}
             playerRings={playerRings}
             teamRings={teamRings}
             setTeamRings={setTeamRings}

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -12,7 +12,6 @@ import Settings from "../../components/UmpirePage/Settings";
 import LoadingSpinner from "../../components/Common/LoadingSpinner";
 import { useRouterLoading } from "../../lib/hooks";
 import Rings from "../../components/Admin/Rings/Rings";
-import { Tournament } from "@prisma/client";
 import {
   RingWithAssignments,
   UmpirePagePlayer,
@@ -20,6 +19,7 @@ import {
   TeamRingWithAssignments,
   UmpirePageTeam
 } from "../../types/umpirepage";
+import { Tournament } from "@prisma/client";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 interface TabPanelProps {
@@ -73,10 +73,28 @@ export const getServerSideProps: GetServerSideProps = async ({
     where: {
       tournamentId: params.id as string
     },
-    include: {
-      player: true,
-      umpire: true,
-      team: true
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      player: {
+        select: {
+          id: true
+        }
+      },
+      umpire: {
+        select: {
+          id: true,
+          responsibility: true,
+          mainUmpire: true
+        }
+      },
+      team: {
+        select: {
+          id: true,
+          name: true
+        }
+      }
     }
   });
 
@@ -84,12 +102,34 @@ export const getServerSideProps: GetServerSideProps = async ({
     where: {
       tournamentId: params.id as string
     },
-    include: {
-      user: true,
-      team: true,
+    select: {
+      id: true,
+      title: true,
+      alias: true,
+      state: true,
+      user: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true
+        }
+      },
+      team: {
+        select: {
+          id: true,
+          name: true
+        }
+      },
       umpire: {
-        include: {
-          user: true
+        select: {
+          id: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true
+            }
+          }
         }
       },
       targets: true

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -135,11 +135,7 @@ export const authConfig = {
         });
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError) {
-          if (error.code == "P2025") {
-            console.log(
-              `Unable to log lastVisit for ${user.id}, user has no player entry`
-            );
-          } else {
+          if (error.code !== "P2025") {
             console.log(
               `Unable to log lastVisit for ${user.id}, error: ${error.code} : ${error.message}`
             );

--- a/pages/api/player/create.ts
+++ b/pages/api/player/create.ts
@@ -71,6 +71,19 @@ export default async function create(
         }
       });
 
+      // Päivitetään pelaajan ammattilaistitteli suoraan pelaajan etunimeen niin sitten sitä ei tarvitse lisätä koodissa jokaiseen paikkaan
+      // Helpottaa varsinkin tuomaristonäkymän koodaamista
+      await prisma.user.update({
+        where: {
+          id: playerData.userId
+        },
+        data: {
+          firstName: playerData.title
+            ? `${playerData.title} ${user.firstName}`
+            : user.firstName
+        }
+      });
+
       const emailTitleFi = `Kiitos ilmoittautumisestasi salamurhaturnaukseen ${user.tournament.name}!`;
       const emailBodyFi = `Kiitos ilmoittautumisestasi! Tuomaristo tarkistaa tietosi vielä ennen pelin alkua, ja saat sähköpostitse vahvistusviestin, kun ilmoittautumisesi on hyväksytty. Tuomaristo ottaa erikseen yhteyttä, mikäli antamiasi tietoja pitää täydentää tai muokata.\n\nTämä on automaattinen vahvistusviesti. Älä vastaa tähän viestiin. Tuomaristo vastaa peliin liittyviin viesteihin osoitteessa tuomaristo@salamurhaajat.net.`;
 
@@ -84,7 +97,7 @@ export default async function create(
         locale === "fi" ? emailBodyFi : emailBodyEn
       );
 
-      res.status(200).json({ player: createdPlayer });
+      return res.status(200).json({ player: createdPlayer });
     } catch (e) {
       console.log(e);
       if (e instanceof Prisma.PrismaClientKnownRequestError) {

--- a/pages/api/tournament/[id]/delete.ts
+++ b/pages/api/tournament/[id]/delete.ts
@@ -46,12 +46,28 @@ export default async function handler(
             console.log(result);
           }
         );
+        const tournament = await prisma.tournament.findUnique({
+          where: {
+            id: tournamentId
+          },
+          include: {
+            users: true
+          }
+        });
+
+        await prisma.verificationToken.deleteMany({
+          where: {
+            identifier: {
+              in: tournament.users.map((user) => user.email)
+            }
+          }
+        }); // Nämä ei poistu turnauksen poistamisen yhteydessä, joten pitää poistaa erikseen.
+
         await prisma.tournament.delete({
           where: {
             id: tournamentId
           }
         });
-        await prisma.verificationToken.deleteMany(); // Nämä ei poistu turnauksen poistamisen yhteydessä, joten pitää poistaa erikseen.
       } catch (error) {
         console.log(error);
         return res.status(500).end();

--- a/pages/api/tournament/[id]/delete.ts
+++ b/pages/api/tournament/[id]/delete.ts
@@ -51,6 +51,7 @@ export default async function handler(
             id: tournamentId
           }
         });
+        await prisma.verificationToken.deleteMany(); // Nämä ei poistu turnauksen poistamisen yhteydessä, joten pitää poistaa erikseen.
       } catch (error) {
         console.log(error);
         return res.status(500).end();

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -55,12 +55,7 @@ export default async function handler(
       new Date(user.tournament.startTime),
       new Date(user.tournament.endTime)
     ) && user.player
-      ? user.player.targets.map((target) => ({
-          ...target.target.user,
-          firstName: target.target.title
-            ? `${target.target.title} ${target.target.user.firstName}`
-            : target.target.user.firstName
-        }))
+      ? user.player.targets.map((target) => target.target.user)
       : [];
 
   const uniqueTargets = targets.filter(

--- a/pages/api/user/[id]/navbar_data.ts
+++ b/pages/api/user/[id]/navbar_data.ts
@@ -31,6 +31,7 @@ export default async function handler(
             select: {
               target: {
                 select: {
+                  title: true,
                   user: {
                     select: {
                       id: true,
@@ -54,7 +55,12 @@ export default async function handler(
       new Date(user.tournament.startTime),
       new Date(user.tournament.endTime)
     ) && user.player
-      ? user.player.targets.map((target) => target.target.user)
+      ? user.player.targets.map((target) => ({
+          ...target.target.user,
+          firstName: target.target.title
+            ? `${target.target.title} ${target.target.user.firstName}`
+            : target.target.user.firstName
+        }))
       : [];
 
   const uniqueTargets = targets.filter(

--- a/pages/tournaments/[tournamentId]/users/[id].tsx
+++ b/pages/tournaments/[tournamentId]/users/[id].tsx
@@ -172,6 +172,8 @@ export default function User({
 
   if (session.status === "loading" || isLoading) return <LoadingSpinner />;
 
+  if (!session.data) return <AuthenticationRequired />;
+
   if (!Boolean(user.player) && user.id !== session.data.user.id) {
     return (
       <div style={{ margin: 2 }}>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -101,6 +101,7 @@
       "editButton": "Edit calendar",
       "cancelButton": "Cancel",
       "nextButton": "Next",
+      "previousButton": "Previous",
       "markdown": "Calendar supports [Markdown syntax](https://www.markdownguide.org/basic-syntax/)",
       "saveButton": "Save changes"
     },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -137,7 +137,8 @@
         "hairLabel": "Hair",
         "heightLabel": "Height",
         "otherInfoLabel": "Appearance, transportation and other details:",
-        "saveButton": "Save"
+        "saveButton": "Save",
+        "markdownNote": "NOTE! These fields support Markdown syntax as well"
       }
     }
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -137,7 +137,8 @@
         "hairLabel": "Hiukset",
         "heightLabel": "Pituus",
         "otherInfoLabel": "Ulkonäkö, kulkuvälineet ja muut lisätiedot:",
-        "saveButton": "Tallenna"
+        "saveButton": "Tallenna",
+        "markdownNote": "Huom! Nämäkin kentät tukevat nyt Markdownia"
       }
     }
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -101,6 +101,7 @@
       "editButton": "Muokkaa kalenteria",
       "cancelButton": "Peruuta",
       "nextButton": "Seuraava",
+      "previousButton": "Edellinen",
       "markdown": "Kalenteri tukee [Markdown-syntaksia](https://www.markdownguide.org/basic-syntax/)",
       "saveButton": "Tallenna muokkaukset"
     },

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -100,7 +100,6 @@ button:hover,
 button.playerTableStateButton:hover {
   background-color: #a50000;
   color: white;
-  font-weight: bold;
 }
 
 .updateform {

--- a/types/umpirepage.ts
+++ b/types/umpirepage.ts
@@ -1,15 +1,38 @@
 import {
   Assignment,
   AssignmentRing,
-  Player,
-  Team,
   TeamAssignment,
   TeamAssignmentRing,
-  Tournament,
-  Umpire,
-  User
+  Tournament
 } from "@prisma/client";
+import { PlayerTitle, PlayerState } from "@prisma/client";
 import { Dispatch, SetStateAction } from "react";
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface Player {
+  id: string;
+  title: PlayerTitle;
+  alias: string;
+  state: PlayerState;
+  colorCode?: string;
+}
+
+interface Umpire {
+  id: string;
+  responsibility: string;
+  mainUmpire: boolean;
+}
+
+interface Team {
+  id: string;
+  name: string;
+  colorCode?: string;
+}
 
 interface PlayerWithUser extends Player {
   user: User;

--- a/types/umpirepage.ts
+++ b/types/umpirepage.ts
@@ -16,16 +16,16 @@ interface User {
 
 interface Player {
   id: string;
-  title: PlayerTitle;
   alias: string;
   state: PlayerState;
+  title?: PlayerTitle;
   colorCode?: string;
 }
 
 interface Umpire {
   id: string;
-  responsibility: string;
   mainUmpire: boolean;
+  responsibility?: string;
 }
 
 interface Team {


### PR DESCRIPTION
Tästä tuli aivan kamala sillisalaattipulari. Tässä on siis erinäisiä pieniä parannuksia, joita olen viimeisen parin kuukauden aikana tehnyt ja (melkein) kaikki ovat sen verran pieniä etten viitsinyt tehdä niistä omia pulareitaan, joten ne ovat nyt kaikki tässä yhdessä. 

### Pelaajasivun muutokset

- Yhdistin pelaajan ammattilaistittelin pelaajan nimeen silloin kun player luodaan. Näin titteliä ei tarvitse joka paikassa erikseen näyttää. 
- Markdown-tuki lisätty kaikkiin pelaajasivun muokattaviin kenttiin.
- Kalenteriin lisäsin "edellinen"-napin, jotta kalenterin sivujen vaihtaminen olisi hieman selkeämpää. 
- Lisäsin pienen tarkistuksen pelaajasivulle, että sivu palauttaa `<AuthenticationRequired>`:n, jos sessio on tyhjä. 
- Korjasin pienen tekstikenttiin liittyvän varoituksen, joka näkyi selaimen konsolissa.

### Tuomaristosivun muutokset

- Tuomaristosivu latasi ihan tolkuttoman määrän turhaa dataa tietokannasta (mm. kaikkien pelaajien kaikki tiedot - esim. koko kalenterit - joita ei todellakaan tarvita tuomaristosivulla). Siivosin hieman ladattavaa dataa. 
- Turnauksen poistossa tietokantaan jäi nextauthin verification tokenit, joten ne poistetaan nyt myös turnauksen poiston yhteydessä. 
- Tuomaristosivulla pelaajalistaus näkyy nyt myös vaikka yksikään pelaaja ei olisi tehnyt ilmoittautumista loppuun. Huomattiin, ettei se näytä puoliksi ilmolomakkeen täyttäneitä pelaajia ennen kuin edes yksi pelaaja on tehnyt ilmoittautumisen loppuun.
- Tuomaristosivu näyttää nyt Alertit onnistuneista etsintäkuulutuksista ja tuomarien asettamisesta.

### Muut

- LastVisitin päivityksen yhteydessä ei enää logata virhettä, jos käyttäjällä ei ole pelaajaa (käytännössä aina tuomareiden käyttäessä Surmaa Vercelin logit täyttyvät näistä).
- Jotain pieniä tyylimuutoksia.